### PR TITLE
update: API呼び出し＆型の自動生成導入

### DIFF
--- a/api/__generated__/application/Application.ts
+++ b/api/__generated__/application/Application.ts
@@ -1,0 +1,201 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  AcceptPartialUpdateData,
+  AcceptPartialUpdatePayload,
+  ApplicationCreateData,
+  ApplicationCreatePayload,
+  ApplicationDeleteData,
+  ApplicationDetailData,
+  ApplicationListData,
+  ApplicationPartialUpdateData,
+  ApplicationPartialUpdatePayload,
+  ApplicationUpdateData,
+  ApplicationUpdatePayload,
+  GetApplication2Data,
+  GetApplicationData,
+  MyComingDetailData,
+  RejectPartialUpdateData,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Application<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name GetApplication
+   * @request GET:/application/job/{job_id}
+   */
+  getApplication = (jobId: number, params: RequestParams = {}) =>
+    this.request<GetApplicationData, void>({
+      path: `/application/job/${jobId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name MyComingDetail
+   * @request GET:/application/my/coming/{user_id}
+   */
+  myComingDetail = (userId: string, params: RequestParams = {}) =>
+    this.request<MyComingDetailData, void>({
+      path: `/application/my/coming/${userId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name GetApplication2
+   * @request GET:/application/my/{user_id}
+   * @originalName getApplication
+   * @duplicate
+   */
+  getApplication2 = (userId: string, params: RequestParams = {}) =>
+    this.request<GetApplication2Data, void>({
+      path: `/application/my/${userId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name AcceptPartialUpdate
+   * @request PATCH:/application/{application_id}/accept
+   */
+  acceptPartialUpdate = (applicationId: string, data: AcceptPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<AcceptPartialUpdateData, void>({
+      path: `/application/${applicationId}/accept`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name RejectPartialUpdate
+   * @request PATCH:/application/{application_id}/reject
+   */
+  rejectPartialUpdate = (applicationId: string, params: RequestParams = {}) =>
+    this.request<RejectPartialUpdateData, void>({
+      path: `/application/${applicationId}/reject`,
+      method: "PATCH",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name ApplicationDelete
+   * @request DELETE:/application/{application_id}
+   */
+  applicationDelete = (applicationId: string, params: RequestParams = {}) =>
+    this.request<ApplicationDeleteData, void>({
+      path: `/application/${applicationId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name ApplicationDetail
+   * @request GET:/application/{application_id}
+   */
+  applicationDetail = (applicationId: string, params: RequestParams = {}) =>
+    this.request<ApplicationDetailData, void>({
+      path: `/application/${applicationId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name ApplicationPartialUpdate
+   * @request PATCH:/application/{application_id}
+   */
+  applicationPartialUpdate = (
+    applicationId: string,
+    data: ApplicationPartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<ApplicationPartialUpdateData, void>({
+      path: `/application/${applicationId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name ApplicationUpdate
+   * @request PUT:/application/{application_id}
+   */
+  applicationUpdate = (applicationId: string, data: ApplicationUpdatePayload, params: RequestParams = {}) =>
+    this.request<ApplicationUpdateData, void>({
+      path: `/application/${applicationId}`,
+      method: "PUT",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name ApplicationList
+   * @request GET:/application
+   */
+  applicationList = (params: RequestParams = {}) =>
+    this.request<ApplicationListData, void>({
+      path: `/application`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags application
+   * @name ApplicationCreate
+   * @request POST:/application
+   */
+  applicationCreate = (data: ApplicationCreatePayload, params: RequestParams = {}) =>
+    this.request<ApplicationCreateData, void>({
+      path: `/application`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/application/data-contracts.ts
+++ b/api/__generated__/application/data-contracts.ts
@@ -1,0 +1,426 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type GetApplicationData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+}[];
+
+export type MyComingDetailData = object;
+
+export type GetApplication2Data = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+  job?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+    _restaurant?: {
+      /** @format int64 */
+      id?: number;
+      /**
+       * @format timestamptz
+       * @default "now"
+       */
+      created_at?: number;
+      name?: string;
+      address?: string;
+      cuisine_type?: string;
+      business_hours?: string;
+      contact_info?: string;
+      profile_image?: string;
+      /** @format timestamptz */
+      updated_at?: number;
+      /** Whether the restaurant is active. */
+      is_active?: boolean;
+      /** @format uuid */
+      companies_id?: string | null;
+      station?: string;
+      access?: string;
+      rating?: number;
+      /** @default "1" */
+      is_approved?: boolean;
+      cuisine_category?: number[] | null;
+    };
+  };
+}[];
+
+export interface AcceptPartialUpdatePayload {
+  message?: string;
+}
+
+export interface AcceptPartialUpdateData {
+  application?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format timestamptz */
+    application_date?: number | null;
+    /** @default "APPLIED" */
+    status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+    notes?: string;
+    /** @format timestamptz */
+    updated_at?: number | null;
+    /** @format int64 */
+    job_id?: number;
+    /** @format uuid */
+    user_id?: string | null;
+    /** @format timestamptz */
+    expiry_date?: number | null;
+    urgent?: boolean;
+    job?: {
+      /** @format int64 */
+      restaurant_id?: number;
+      restaurant?: {
+        /** @format int64 */
+        id?: number;
+      } | null;
+    };
+  };
+  worksession?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format timestamptz */
+    check_in_time?: number;
+    /** @format timestamptz */
+    check_out_time?: number;
+    total_hours?: number;
+    location_data?: string;
+    status?:
+      | "SCHEDULED"
+      | "IN_PROGRESS"
+      | "CANCELED_BY_CHEF"
+      | "CANCELED_BY_RESTAURANT"
+      | "COMPLETED"
+      | "VERIFIED"
+      | "DISPUTE"
+      | "ESCALATED"
+      | "PAID"
+      | "CANCELED";
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    user_id?: string | null;
+    /** @format int64 */
+    restaurant_id?: number;
+    /** @format int64 */
+    job_id?: number;
+    /** @format int64 */
+    paid_amount?: number;
+    chef_feedback?: string;
+    restaurant_feedback?: string;
+    /** @format int64 */
+    chef_rating?: number;
+    /** @format int64 */
+    restaurant_rating?: number;
+  };
+  message?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    content?: string;
+    is_read?: boolean;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    chef_id?: string;
+    sender_type?: "chef" | "restaurant";
+    /** @format int64 */
+    restaurant_id?: number | null;
+    /** @format int64 */
+    worksession_id?: number;
+  };
+}
+
+export type RejectPartialUpdateData = object;
+
+export type ApplicationDeleteData = object;
+
+export interface ApplicationDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}
+
+export interface ApplicationPartialUpdatePayload {
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}
+
+export interface ApplicationPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}
+
+export interface ApplicationUpdatePayload {
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}
+
+export interface ApplicationUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}
+
+export type ApplicationListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}[];
+
+export interface ApplicationCreatePayload {
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}
+
+export interface ApplicationCreateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  application_date?: number | null;
+  /** @default "APPLIED" */
+  status?: "APPLIED" | "REJECTED" | "ACCEPTED" | "CANCELED" | "DONE";
+  notes?: string;
+  /** @format timestamptz */
+  updated_at?: number | null;
+  /** @format int64 */
+  job_id?: number;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format timestamptz */
+  expiry_date?: number | null;
+  urgent?: boolean;
+}

--- a/api/__generated__/application/http-client.ts
+++ b/api/__generated__/application/http-client.ts
@@ -1,0 +1,146 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  axiosInstance: AxiosInstance;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public instance: AxiosInstance;
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private secure?: boolean;
+  private format?: ResponseType;
+
+  constructor({ axiosInstance, securityWorker, secure, format, ...axiosConfig }: ApiConfig<SecurityDataType> = {}) {
+    this.instance = axiosInstance;
+    this.instance.defaults.baseURL = "https://xcti-onox-8bdw.n7e.xano.io/api:MJ8mZ3fN";
+    this.secure = secure;
+    this.format = format;
+    this.securityWorker = securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected mergeRequestParams(params1: AxiosRequestConfig, params2?: AxiosRequestConfig): AxiosRequestConfig {
+    const method = params1.method || (params2 && params2.method);
+
+    return {
+      ...this.instance.defaults,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...((method && this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected stringifyFormItem(formItem: unknown) {
+    if (typeof formItem === "object" && formItem !== null) {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
+  protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
+    return Object.keys(input || {}).reduce((formData, key) => {
+      const property = input[key];
+      const propertyContent: any[] = property instanceof Array ? property : [property];
+
+      for (const formItem of propertyContent) {
+        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
+      }
+
+      return formData;
+    }, new FormData());
+  }
+
+  public request = async <T = any, _E = any>({
+    secure,
+    path,
+    type,
+    query,
+    format,
+    body,
+    ...params
+  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const responseFormat = format || this.format || undefined;
+
+    if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
+      body = this.createFormData(body as Record<string, unknown>);
+    }
+
+    if (type === ContentType.Text && body && body !== null && typeof body !== "string") {
+      body = JSON.stringify(body);
+    }
+
+    return this.instance.request({
+      ...requestParams,
+      headers: {
+        ...(requestParams.headers || {}),
+        ...(type ? { "Content-Type": type } : {}),
+      },
+      params: query,
+      responseType: responseFormat,
+      data: body,
+      url: path,
+    });
+  };
+}

--- a/api/__generated__/authentication/Auth.ts
+++ b/api/__generated__/authentication/Auth.ts
@@ -1,0 +1,72 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  GetAuthData,
+  LoginCreateData,
+  LoginCreatePayload,
+  SignupCreateData,
+  SignupCreatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Auth<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Login and retrieve an authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags auth
+   * @name LoginCreate
+   * @summary Login and retrieve an authentication token
+   * @request POST:/auth/login
+   */
+  loginCreate = (data: LoginCreatePayload, params: RequestParams = {}) =>
+    this.request<LoginCreateData, void>({
+      path: `/auth/login`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get the user record belonging to the authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags auth
+   * @name GetAuth
+   * @summary Get the user record belonging to the authentication token
+   * @request GET:/auth/me
+   */
+  getAuth = (params: RequestParams = {}) =>
+    this.request<GetAuthData, void>({
+      path: `/auth/me`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Signup and retrieve an authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags auth
+   * @name SignupCreate
+   * @summary Signup and retrieve an authentication token
+   * @request POST:/auth/signup
+   */
+  signupCreate = (data: SignupCreatePayload, params: RequestParams = {}) =>
+    this.request<SignupCreateData, void>({
+      path: `/auth/signup`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/authentication/data-contracts.ts
+++ b/api/__generated__/authentication/data-contracts.ts
@@ -1,0 +1,103 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export interface LoginCreatePayload {
+  /** @format email */
+  email?: string;
+  password?: string;
+}
+
+export interface LoginCreateData {
+  authToken?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    /** @format password */
+    password?: string;
+  };
+}
+
+export interface GetAuthData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  user_type?: string;
+  status?: string;
+  /** @format date */
+  last_login_at?: string | null;
+  /** @format date */
+  updated_at?: string | null;
+  skills?: string[];
+  experience_level?: string;
+  bio?: string;
+  certifications?: string[];
+  /** @format date */
+  dateofbirth?: string | null;
+  profile_image?: string;
+  is_approved?: boolean;
+}
+
+export interface SignupCreatePayload {
+  name?: string;
+  /** @format email */
+  email?: string;
+  password?: string;
+}
+
+export interface SignupCreateData {
+  authToken?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    /** @format password */
+    password?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+}

--- a/api/__generated__/authentication/http-client.ts
+++ b/api/__generated__/authentication/http-client.ts
@@ -1,0 +1,146 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  axiosInstance: AxiosInstance;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public instance: AxiosInstance;
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private secure?: boolean;
+  private format?: ResponseType;
+
+  constructor({ axiosInstance, securityWorker, secure, format, ...axiosConfig }: ApiConfig<SecurityDataType> = {}) {
+    this.instance = axiosInstance;
+    this.instance.defaults.baseURL = "https://xcti-onox-8bdw.n7e.xano.io/api:xaJlLYDj";
+    this.secure = secure;
+    this.format = format;
+    this.securityWorker = securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected mergeRequestParams(params1: AxiosRequestConfig, params2?: AxiosRequestConfig): AxiosRequestConfig {
+    const method = params1.method || (params2 && params2.method);
+
+    return {
+      ...this.instance.defaults,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...((method && this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected stringifyFormItem(formItem: unknown) {
+    if (typeof formItem === "object" && formItem !== null) {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
+  protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
+    return Object.keys(input || {}).reduce((formData, key) => {
+      const property = input[key];
+      const propertyContent: any[] = property instanceof Array ? property : [property];
+
+      for (const formItem of propertyContent) {
+        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
+      }
+
+      return formData;
+    }, new FormData());
+  }
+
+  public request = async <T = any, _E = any>({
+    secure,
+    path,
+    type,
+    query,
+    format,
+    body,
+    ...params
+  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const responseFormat = format || this.format || undefined;
+
+    if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
+      body = this.createFormData(body as Record<string, unknown>);
+    }
+
+    if (type === ContentType.Text && body && body !== null && typeof body !== "string") {
+      body = JSON.stringify(body);
+    }
+
+    return this.instance.request({
+      ...requestParams,
+      headers: {
+        ...(requestParams.headers || {}),
+        ...(type ? { "Content-Type": type } : {}),
+      },
+      params: query,
+      responseType: responseFormat,
+      data: body,
+      url: path,
+    });
+  };
+}

--- a/api/__generated__/chef-connect/Adminlog.ts
+++ b/api/__generated__/chef-connect/Adminlog.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  AdminlogCreateData,
+  AdminlogCreatePayload,
+  AdminlogDeleteData,
+  AdminlogDetailData,
+  AdminlogListData,
+  AdminlogPartialUpdateData,
+  AdminlogPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Adminlog<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete adminlog record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags adminlog
+   * @name AdminlogDelete
+   * @summary Delete adminlog record.
+   * @request DELETE:/adminlog/{adminlog_id}
+   */
+  adminlogDelete = (adminlogId: number, params: RequestParams = {}) =>
+    this.request<AdminlogDeleteData, void>({
+      path: `/adminlog/${adminlogId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get adminlog record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags adminlog
+   * @name AdminlogDetail
+   * @summary Get adminlog record
+   * @request GET:/adminlog/{adminlog_id}
+   */
+  adminlogDetail = (adminlogId: number, params: RequestParams = {}) =>
+    this.request<AdminlogDetailData, void>({
+      path: `/adminlog/${adminlogId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit adminlog record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags adminlog
+   * @name AdminlogPartialUpdate
+   * @summary Edit adminlog record
+   * @request PATCH:/adminlog/{adminlog_id}
+   */
+  adminlogPartialUpdate = (adminlogId: number, data: AdminlogPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<AdminlogPartialUpdateData, void>({
+      path: `/adminlog/${adminlogId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all adminlog records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags adminlog
+   * @name AdminlogList
+   * @summary Query all adminlog records
+   * @request GET:/adminlog
+   */
+  adminlogList = (params: RequestParams = {}) =>
+    this.request<AdminlogListData, void>({
+      path: `/adminlog`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add adminlog record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags adminlog
+   * @name AdminlogCreate
+   * @summary Add adminlog record
+   * @request POST:/adminlog
+   */
+  adminlogCreate = (data: AdminlogCreatePayload, params: RequestParams = {}) =>
+    this.request<AdminlogCreateData, void>({
+      path: `/adminlog`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/ChefReview.ts
+++ b/api/__generated__/chef-connect/ChefReview.ts
@@ -1,0 +1,144 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  ByRestaurantDetailData,
+  BySessionDetailData,
+  ByUserDetailData,
+  ChefReviewCreateData,
+  ChefReviewCreatePayload,
+  ChefReviewDeleteData,
+  ChefReviewDetailData,
+  ChefReviewListData,
+  ChefReviewPartialUpdateData,
+  ChefReviewPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class ChefReview<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name ByRestaurantDetail
+   * @request GET:/chef_review/byRestaurant/{restaurant_id}
+   */
+  byRestaurantDetail = (restaurantId: number, params: RequestParams = {}) =>
+    this.request<ByRestaurantDetailData, void>({
+      path: `/chef_review/byRestaurant/${restaurantId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name BySessionDetail
+   * @request GET:/chef_review/bySession/{worksession_id}
+   */
+  bySessionDetail = (worksessionId: number, params: RequestParams = {}) =>
+    this.request<BySessionDetailData, void>({
+      path: `/chef_review/bySession/${worksessionId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name ByUserDetail
+   * @request GET:/chef_review/byUser/{user_id}
+   */
+  byUserDetail = (userId: string, params: RequestParams = {}) =>
+    this.request<ByUserDetailData, void>({
+      path: `/chef_review/byUser/${userId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name ChefReviewDelete
+   * @request DELETE:/chef_review/{chef_review_id}
+   */
+  chefReviewDelete = (chefReviewId: number, params: RequestParams = {}) =>
+    this.request<ChefReviewDeleteData, void>({
+      path: `/chef_review/${chefReviewId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name ChefReviewDetail
+   * @request GET:/chef_review/{chef_review_id}
+   */
+  chefReviewDetail = (chefReviewId: number, params: RequestParams = {}) =>
+    this.request<ChefReviewDetailData, void>({
+      path: `/chef_review/${chefReviewId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name ChefReviewPartialUpdate
+   * @request PATCH:/chef_review/{chef_review_id}
+   */
+  chefReviewPartialUpdate = (chefReviewId: number, data: ChefReviewPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<ChefReviewPartialUpdateData, void>({
+      path: `/chef_review/${chefReviewId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name ChefReviewList
+   * @request GET:/chef_review
+   */
+  chefReviewList = (params: RequestParams = {}) =>
+    this.request<ChefReviewListData, void>({
+      path: `/chef_review`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_review
+   * @name ChefReviewCreate
+   * @request POST:/chef_review
+   */
+  chefReviewCreate = (data: ChefReviewCreatePayload, params: RequestParams = {}) =>
+    this.request<ChefReviewCreateData, void>({
+      path: `/chef_review`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Files.ts
+++ b/api/__generated__/chef-connect/Files.ts
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  FilesCreateData,
+  FilesDeleteData,
+  FilesDetailData,
+  FilesListData,
+  FilesPartialUpdateData,
+} from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class Files<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete Files record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags files
+   * @name FilesDelete
+   * @summary Delete Files record.
+   * @request DELETE:/files/{files_id}
+   */
+  filesDelete = (filesId: string, params: RequestParams = {}) =>
+    this.request<FilesDeleteData, void>({
+      path: `/files/${filesId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get Files record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags files
+   * @name FilesDetail
+   * @summary Get Files record
+   * @request GET:/files/{files_id}
+   */
+  filesDetail = (filesId: string, params: RequestParams = {}) =>
+    this.request<FilesDetailData, void>({
+      path: `/files/${filesId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit Files record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags files
+   * @name FilesPartialUpdate
+   * @summary Edit Files record
+   * @request PATCH:/files/{files_id}
+   */
+  filesPartialUpdate = (filesId: string, params: RequestParams = {}) =>
+    this.request<FilesPartialUpdateData, void>({
+      path: `/files/${filesId}`,
+      method: "PATCH",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all Files records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags files
+   * @name FilesList
+   * @summary Query all Files records
+   * @request GET:/files
+   */
+  filesList = (params: RequestParams = {}) =>
+    this.request<FilesListData, void>({
+      path: `/files`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add Files record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags files
+   * @name FilesCreate
+   * @summary Add Files record
+   * @request POST:/files
+   */
+  filesCreate = (params: RequestParams = {}) =>
+    this.request<FilesCreateData, void>({
+      path: `/files`,
+      method: "POST",
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Job.ts
+++ b/api/__generated__/chef-connect/Job.ts
@@ -1,0 +1,136 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  CompanyDetailData,
+  DeleteJobData,
+  GetJob2Data,
+  GetJobData,
+  PatchJobData,
+  PatchJobPayload,
+  PostJobData,
+  PostJobPayload,
+  RestaurantDetailData,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Job<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job
+   * @name CompanyDetail
+   * @request GET:/job/company/{companyId}
+   */
+  companyDetail = (companyId: string, params: RequestParams = {}) =>
+    this.request<CompanyDetailData, void>({
+      path: `/job/company/${companyId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job
+   * @name RestaurantDetail
+   * @request GET:/job/restaurant/{restaurant_id}
+   */
+  restaurantDetail = (restaurantId: number, params: RequestParams = {}) =>
+    this.request<RestaurantDetailData, void>({
+      path: `/job/restaurant/${restaurantId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Delete job record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job
+   * @name DeleteJob
+   * @summary Delete job record.
+   * @request DELETE:/job/{job_id}
+   */
+  deleteJob = (jobId: number, params: RequestParams = {}) =>
+    this.request<DeleteJobData, void>({
+      path: `/job/${jobId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get job record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job
+   * @name GetJob
+   * @summary Get job record
+   * @request GET:/job/{job_id}
+   */
+  getJob = (jobId: number, params: RequestParams = {}) =>
+    this.request<GetJobData, void>({
+      path: `/job/${jobId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit job record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job
+   * @name PatchJob
+   * @summary Edit job record
+   * @request PATCH:/job/{job_id}
+   */
+  patchJob = (jobId: number, data: PatchJobPayload, params: RequestParams = {}) =>
+    this.request<PatchJobData, void>({
+      path: `/job/${jobId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all job records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job
+   * @name GetJob2
+   * @summary Query all job records
+   * @request GET:/job
+   * @originalName getJob
+   * @duplicate
+   */
+  getJob2 = (params: RequestParams = {}) =>
+    this.request<GetJob2Data, void>({
+      path: `/job`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add job record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job
+   * @name PostJob
+   * @summary Add job record
+   * @request POST:/job
+   */
+  postJob = (data: PostJobPayload, params: RequestParams = {}) =>
+    this.request<PostJobData, void>({
+      path: `/job`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/JobWithCheck.ts
+++ b/api/__generated__/chef-connect/JobWithCheck.ts
@@ -1,0 +1,34 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import { JobWithCheckCreateData, JobWithCheckCreatePayload } from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class JobWithCheck<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Add job record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags job_with_check
+   * @name JobWithCheckCreate
+   * @summary Add job record
+   * @request POST:/job_with_check
+   */
+  jobWithCheckCreate = (data: JobWithCheckCreatePayload, params: RequestParams = {}) =>
+    this.request<JobWithCheckCreateData, void>({
+      path: `/job_with_check`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Message.ts
+++ b/api/__generated__/chef-connect/Message.ts
@@ -1,0 +1,119 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  MessageCreateData,
+  MessageCreatePayload,
+  MessageDeleteData,
+  MessageDetailData,
+  MessageListData,
+  MessagePartialUpdateData,
+  MessagePartialUpdatePayload,
+  WorksessionDetailData,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Message<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags message
+   * @name WorksessionDetail
+   * @request GET:/message/worksession/{worksession_id}
+   */
+  worksessionDetail = (worksessionId: number, params: RequestParams = {}) =>
+    this.request<WorksessionDetailData, void>({
+      path: `/message/worksession/${worksessionId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Delete message record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags message
+   * @name MessageDelete
+   * @summary Delete message record.
+   * @request DELETE:/message/{message_id}
+   */
+  messageDelete = (messageId: number, params: RequestParams = {}) =>
+    this.request<MessageDeleteData, void>({
+      path: `/message/${messageId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get message record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags message
+   * @name MessageDetail
+   * @summary Get message record
+   * @request GET:/message/{message_id}
+   */
+  messageDetail = (messageId: number, params: RequestParams = {}) =>
+    this.request<MessageDetailData, void>({
+      path: `/message/${messageId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit message record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags message
+   * @name MessagePartialUpdate
+   * @summary Edit message record
+   * @request PATCH:/message/{message_id}
+   */
+  messagePartialUpdate = (messageId: number, data: MessagePartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<MessagePartialUpdateData, void>({
+      path: `/message/${messageId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all message records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags message
+   * @name MessageList
+   * @summary Query all message records
+   * @request GET:/message
+   */
+  messageList = (params: RequestParams = {}) =>
+    this.request<MessageListData, void>({
+      path: `/message`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add message record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags message
+   * @name MessageCreate
+   * @summary Add message record
+   * @request POST:/message
+   */
+  messageCreate = (data: MessageCreatePayload, params: RequestParams = {}) =>
+    this.request<MessageCreateData, void>({
+      path: `/message`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Messageattachment.ts
+++ b/api/__generated__/chef-connect/Messageattachment.ts
@@ -1,0 +1,108 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  MessageattachmentCreateData,
+  MessageattachmentCreatePayload,
+  MessageattachmentDeleteData,
+  MessageattachmentDetailData,
+  MessageattachmentListData,
+  MessageattachmentPartialUpdateData,
+  MessageattachmentPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Messageattachment<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete messageAttachment record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags messageattachment
+   * @name MessageattachmentDelete
+   * @summary Delete messageAttachment record.
+   * @request DELETE:/messageattachment/{messageattachment_id}
+   */
+  messageattachmentDelete = (messageattachmentId: string, params: RequestParams = {}) =>
+    this.request<MessageattachmentDeleteData, void>({
+      path: `/messageattachment/${messageattachmentId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get messageAttachment record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags messageattachment
+   * @name MessageattachmentDetail
+   * @summary Get messageAttachment record
+   * @request GET:/messageattachment/{messageattachment_id}
+   */
+  messageattachmentDetail = (messageattachmentId: string, params: RequestParams = {}) =>
+    this.request<MessageattachmentDetailData, void>({
+      path: `/messageattachment/${messageattachmentId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit messageAttachment record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags messageattachment
+   * @name MessageattachmentPartialUpdate
+   * @summary Edit messageAttachment record
+   * @request PATCH:/messageattachment/{messageattachment_id}
+   */
+  messageattachmentPartialUpdate = (
+    messageattachmentId: string,
+    data: MessageattachmentPartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<MessageattachmentPartialUpdateData, void>({
+      path: `/messageattachment/${messageattachmentId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all messageAttachment records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags messageattachment
+   * @name MessageattachmentList
+   * @summary Query all messageAttachment records
+   * @request GET:/messageattachment
+   */
+  messageattachmentList = (params: RequestParams = {}) =>
+    this.request<MessageattachmentListData, void>({
+      path: `/messageattachment`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add messageAttachment record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags messageattachment
+   * @name MessageattachmentCreate
+   * @summary Add messageAttachment record
+   * @request POST:/messageattachment
+   */
+  messageattachmentCreate = (data: MessageattachmentCreatePayload, params: RequestParams = {}) =>
+    this.request<MessageattachmentCreateData, void>({
+      path: `/messageattachment`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Notification.ts
+++ b/api/__generated__/chef-connect/Notification.ts
@@ -1,0 +1,108 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  NotificationCreateData,
+  NotificationCreatePayload,
+  NotificationDeleteData,
+  NotificationDetailData,
+  NotificationListData,
+  NotificationPartialUpdateData,
+  NotificationPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Notification<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete notification record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags notification
+   * @name NotificationDelete
+   * @summary Delete notification record.
+   * @request DELETE:/notification/{notification_id}
+   */
+  notificationDelete = (notificationId: number, params: RequestParams = {}) =>
+    this.request<NotificationDeleteData, void>({
+      path: `/notification/${notificationId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get notification record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags notification
+   * @name NotificationDetail
+   * @summary Get notification record
+   * @request GET:/notification/{notification_id}
+   */
+  notificationDetail = (notificationId: number, params: RequestParams = {}) =>
+    this.request<NotificationDetailData, void>({
+      path: `/notification/${notificationId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit notification record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags notification
+   * @name NotificationPartialUpdate
+   * @summary Edit notification record
+   * @request PATCH:/notification/{notification_id}
+   */
+  notificationPartialUpdate = (
+    notificationId: number,
+    data: NotificationPartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<NotificationPartialUpdateData, void>({
+      path: `/notification/${notificationId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all notification records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags notification
+   * @name NotificationList
+   * @summary Query all notification records
+   * @request GET:/notification
+   */
+  notificationList = (params: RequestParams = {}) =>
+    this.request<NotificationListData, void>({
+      path: `/notification`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add notification record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags notification
+   * @name NotificationCreate
+   * @summary Add notification record
+   * @request POST:/notification
+   */
+  notificationCreate = (data: NotificationCreatePayload, params: RequestParams = {}) =>
+    this.request<NotificationCreateData, void>({
+      path: `/notification`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Payment.ts
+++ b/api/__generated__/chef-connect/Payment.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  PaymentCreateData,
+  PaymentCreatePayload,
+  PaymentDeleteData,
+  PaymentDetailData,
+  PaymentListData,
+  PaymentPartialUpdateData,
+  PaymentPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Payment<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete payment record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags payment
+   * @name PaymentDelete
+   * @summary Delete payment record.
+   * @request DELETE:/payment/{payment_id}
+   */
+  paymentDelete = (paymentId: number, params: RequestParams = {}) =>
+    this.request<PaymentDeleteData, void>({
+      path: `/payment/${paymentId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get payment record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags payment
+   * @name PaymentDetail
+   * @summary Get payment record
+   * @request GET:/payment/{payment_id}
+   */
+  paymentDetail = (paymentId: number, params: RequestParams = {}) =>
+    this.request<PaymentDetailData, void>({
+      path: `/payment/${paymentId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit payment record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags payment
+   * @name PaymentPartialUpdate
+   * @summary Edit payment record
+   * @request PATCH:/payment/{payment_id}
+   */
+  paymentPartialUpdate = (paymentId: number, data: PaymentPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<PaymentPartialUpdateData, void>({
+      path: `/payment/${paymentId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all payment records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags payment
+   * @name PaymentList
+   * @summary Query all payment records
+   * @request GET:/payment
+   */
+  paymentList = (params: RequestParams = {}) =>
+    this.request<PaymentListData, void>({
+      path: `/payment`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add payment record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags payment
+   * @name PaymentCreate
+   * @summary Add payment record
+   * @request POST:/payment
+   */
+  paymentCreate = (data: PaymentCreatePayload, params: RequestParams = {}) =>
+    this.request<PaymentCreateData, void>({
+      path: `/payment`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Photos.ts
+++ b/api/__generated__/chef-connect/Photos.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  PhotosCreateData,
+  PhotosCreatePayload,
+  PhotosDeleteData,
+  PhotosDetailData,
+  PhotosListData,
+  PhotosPartialUpdateData,
+  PhotosPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Photos<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete Photos record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags photos
+   * @name PhotosDelete
+   * @summary Delete Photos record.
+   * @request DELETE:/photos/{photos_id}
+   */
+  photosDelete = (photosId: string, params: RequestParams = {}) =>
+    this.request<PhotosDeleteData, void>({
+      path: `/photos/${photosId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get Photos record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags photos
+   * @name PhotosDetail
+   * @summary Get Photos record
+   * @request GET:/photos/{photos_id}
+   */
+  photosDetail = (photosId: string, params: RequestParams = {}) =>
+    this.request<PhotosDetailData, void>({
+      path: `/photos/${photosId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit Photos record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags photos
+   * @name PhotosPartialUpdate
+   * @summary Edit Photos record
+   * @request PATCH:/photos/{photos_id}
+   */
+  photosPartialUpdate = (photosId: string, data: PhotosPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<PhotosPartialUpdateData, void>({
+      path: `/photos/${photosId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all Photos records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags photos
+   * @name PhotosList
+   * @summary Query all Photos records
+   * @request GET:/photos
+   */
+  photosList = (params: RequestParams = {}) =>
+    this.request<PhotosListData, void>({
+      path: `/photos`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add Photos record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags photos
+   * @name PhotosCreate
+   * @summary Add Photos record
+   * @request POST:/photos
+   */
+  photosCreate = (data: PhotosCreatePayload, params: RequestParams = {}) =>
+    this.request<PhotosCreateData, void>({
+      path: `/photos`,
+      method: "POST",
+      body: data,
+      type: ContentType.FormData,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Restaurant.ts
+++ b/api/__generated__/chef-connect/Restaurant.ts
@@ -1,0 +1,119 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  CompanyDetailResult,
+  RestaurantCreateData,
+  RestaurantCreatePayload,
+  RestaurantDeleteData,
+  RestaurantDetailResult,
+  RestaurantListData,
+  RestaurantPartialUpdateData,
+  RestaurantPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Restaurant<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name CompanyDetail
+   * @request GET:/restaurant/company/{company_id}
+   */
+  companyDetail = (companyId: string, params: RequestParams = {}) =>
+    this.request<CompanyDetailResult, void>({
+      path: `/restaurant/company/${companyId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Delete restaurant record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name RestaurantDelete
+   * @summary Delete restaurant record.
+   * @request DELETE:/restaurant/{restaurant_id}
+   */
+  restaurantDelete = (restaurantId: number, params: RequestParams = {}) =>
+    this.request<RestaurantDeleteData, void>({
+      path: `/restaurant/${restaurantId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get restaurant record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name RestaurantDetail
+   * @summary Get restaurant record
+   * @request GET:/restaurant/{restaurant_id}
+   */
+  restaurantDetail = (restaurantId: number, params: RequestParams = {}) =>
+    this.request<RestaurantDetailResult, void>({
+      path: `/restaurant/${restaurantId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit restaurant record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name RestaurantPartialUpdate
+   * @summary Edit restaurant record
+   * @request PATCH:/restaurant/{restaurant_id}
+   */
+  restaurantPartialUpdate = (restaurantId: number, data: RestaurantPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<RestaurantPartialUpdateData, void>({
+      path: `/restaurant/${restaurantId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all restaurant records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name RestaurantList
+   * @summary Query all restaurant records
+   * @request GET:/restaurant
+   */
+  restaurantList = (params: RequestParams = {}) =>
+    this.request<RestaurantListData, void>({
+      path: `/restaurant`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add restaurant record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name RestaurantCreate
+   * @summary Add restaurant record
+   * @request POST:/restaurant
+   */
+  restaurantCreate = (data: RestaurantCreatePayload, params: RequestParams = {}) =>
+    this.request<RestaurantCreateData, void>({
+      path: `/restaurant`,
+      method: "POST",
+      body: data,
+      type: ContentType.FormData,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/RestaurantCompany.ts
+++ b/api/__generated__/chef-connect/RestaurantCompany.ts
@@ -1,0 +1,31 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import { RestaurantCompanyDetailData } from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class RestaurantCompany<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_company
+   * @name RestaurantCompanyDetail
+   * @request GET:/restaurant_company/{company_id}
+   */
+  restaurantCompanyDetail = (companyId: string, params: RequestParams = {}) =>
+    this.request<RestaurantCompanyDetailData, void>({
+      path: `/restaurant_company/${companyId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/RestaurantCuisine.ts
+++ b/api/__generated__/chef-connect/RestaurantCuisine.ts
@@ -1,0 +1,31 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import { RestaurantCuisineListData } from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class RestaurantCuisine<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_cuisine
+   * @name RestaurantCuisineList
+   * @request GET:/restaurant_cuisine
+   */
+  restaurantCuisineList = (params: RequestParams = {}) =>
+    this.request<RestaurantCuisineListData, void>({
+      path: `/restaurant_cuisine`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/RestaurantJob.ts
+++ b/api/__generated__/chef-connect/RestaurantJob.ts
@@ -1,0 +1,31 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import { RestaurantJobDetailData } from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class RestaurantJob<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_job
+   * @name RestaurantJobDetail
+   * @request GET:/restaurant_job/{restaurant_id}
+   */
+  restaurantJobDetail = (restaurantId: number, params: RequestParams = {}) =>
+    this.request<RestaurantJobDetailData, void>({
+      path: `/restaurant_job/${restaurantId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/RestaurantReview.ts
+++ b/api/__generated__/chef-connect/RestaurantReview.ts
@@ -1,0 +1,148 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  ByChefDetailData,
+  ByRestaurantDetailResult,
+  BySessionDetailResult,
+  RestaurantReviewCreateData,
+  RestaurantReviewCreatePayload,
+  RestaurantReviewDeleteData,
+  RestaurantReviewDetailData,
+  RestaurantReviewListData,
+  RestaurantReviewPartialUpdateData,
+  RestaurantReviewPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class RestaurantReview<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name ByChefDetail
+   * @request GET:/restaurant_review/byChef/{user_id}
+   */
+  byChefDetail = (userId: string, params: RequestParams = {}) =>
+    this.request<ByChefDetailData, void>({
+      path: `/restaurant_review/byChef/${userId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name ByRestaurantDetail
+   * @request GET:/restaurant_review/byRestaurant/{restaurant_id}
+   */
+  byRestaurantDetail = (restaurantId: number, params: RequestParams = {}) =>
+    this.request<ByRestaurantDetailResult, void>({
+      path: `/restaurant_review/byRestaurant/${restaurantId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name BySessionDetail
+   * @request GET:/restaurant_review/bySession/{worksession_id}
+   */
+  bySessionDetail = (worksessionId: number, params: RequestParams = {}) =>
+    this.request<BySessionDetailResult, void>({
+      path: `/restaurant_review/bySession/${worksessionId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name RestaurantReviewDelete
+   * @request DELETE:/restaurant_review/{restaurant_review_id}
+   */
+  restaurantReviewDelete = (restaurantReviewId: number, params: RequestParams = {}) =>
+    this.request<RestaurantReviewDeleteData, void>({
+      path: `/restaurant_review/${restaurantReviewId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name RestaurantReviewDetail
+   * @request GET:/restaurant_review/{restaurant_review_id}
+   */
+  restaurantReviewDetail = (restaurantReviewId: number, params: RequestParams = {}) =>
+    this.request<RestaurantReviewDetailData, void>({
+      path: `/restaurant_review/${restaurantReviewId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name RestaurantReviewPartialUpdate
+   * @request PATCH:/restaurant_review/{restaurant_review_id}
+   */
+  restaurantReviewPartialUpdate = (
+    restaurantReviewId: number,
+    data: RestaurantReviewPartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<RestaurantReviewPartialUpdateData, void>({
+      path: `/restaurant_review/${restaurantReviewId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name RestaurantReviewList
+   * @request GET:/restaurant_review
+   */
+  restaurantReviewList = (params: RequestParams = {}) =>
+    this.request<RestaurantReviewListData, void>({
+      path: `/restaurant_review`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_review
+   * @name RestaurantReviewCreate
+   * @request POST:/restaurant_review
+   */
+  restaurantReviewCreate = (data: RestaurantReviewCreatePayload, params: RequestParams = {}) =>
+    this.request<RestaurantReviewCreateData, void>({
+      path: `/restaurant_review`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/User.ts
+++ b/api/__generated__/chef-connect/User.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  UserCreateData,
+  UserCreatePayload,
+  UserDeleteData,
+  UserDetailData,
+  UserListData,
+  UserPartialUpdateData,
+  UserPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class User<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete user record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags user
+   * @name UserDelete
+   * @summary Delete user record.
+   * @request DELETE:/user/{user_id}
+   */
+  userDelete = (userId: string, params: RequestParams = {}) =>
+    this.request<UserDeleteData, void>({
+      path: `/user/${userId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get user record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags user
+   * @name UserDetail
+   * @summary Get user record
+   * @request GET:/user/{user_id}
+   */
+  userDetail = (userId: string, params: RequestParams = {}) =>
+    this.request<UserDetailData, void>({
+      path: `/user/${userId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit user record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags user
+   * @name UserPartialUpdate
+   * @summary Edit user record
+   * @request PATCH:/user/{user_id}
+   */
+  userPartialUpdate = (userId: string, data: UserPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<UserPartialUpdateData, void>({
+      path: `/user/${userId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.FormData,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all user records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags user
+   * @name UserList
+   * @summary Query all user records
+   * @request GET:/user
+   */
+  userList = (params: RequestParams = {}) =>
+    this.request<UserListData, void>({
+      path: `/user`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add user record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags user
+   * @name UserCreate
+   * @summary Add user record
+   * @request POST:/user
+   */
+  userCreate = (data: UserCreatePayload, params: RequestParams = {}) =>
+    this.request<UserCreateData, void>({
+      path: `/user`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/Worksession.ts
+++ b/api/__generated__/chef-connect/Worksession.ts
@@ -1,0 +1,209 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  ApplicationDetailData,
+  ApplicationDetailParams,
+  FinishPartialUpdateData,
+  FinishPartialUpdatePayload,
+  RestaurantTodoDetailData,
+  StartPartialUpdateData,
+  StartPartialUpdatePayload,
+  UserTodoDetailData,
+  VerifyPartialUpdateData,
+  VerifyPartialUpdatePayload,
+  WorksessionCreateData,
+  WorksessionCreatePayload,
+  WorksessionDeleteData,
+  WorksessionDetailResult,
+  WorksessionListData,
+  WorksessionPartialUpdateData,
+  WorksessionPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Worksession<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name ApplicationDetail
+   * @request GET:/worksession/application/{application_id}
+   */
+  applicationDetail = ({ applicationId, ...query }: ApplicationDetailParams, params: RequestParams = {}) =>
+    this.request<ApplicationDetailData, void>({
+      path: `/worksession/application/${applicationId}`,
+      method: "GET",
+      query: query,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name RestaurantTodoDetail
+   * @request GET:/worksession/restaurant_todo/{job_id}
+   */
+  restaurantTodoDetail = (jobId: number, params: RequestParams = {}) =>
+    this.request<RestaurantTodoDetailData, void>({
+      path: `/worksession/restaurant_todo/${jobId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name UserTodoDetail
+   * @request GET:/worksession/user_todo/{user_id}
+   */
+  userTodoDetail = (userId: string, params: RequestParams = {}) =>
+    this.request<UserTodoDetailData, void>({
+      path: `/worksession/user_todo/${userId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name FinishPartialUpdate
+   * @request PATCH:/worksession/{worksession_id}/finish
+   */
+  finishPartialUpdate = (worksessionId: number, data: FinishPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<FinishPartialUpdateData, void>({
+      path: `/worksession/${worksessionId}/finish`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name StartPartialUpdate
+   * @request PATCH:/worksession/{worksession_id}/start
+   */
+  startPartialUpdate = (worksessionId: number, data: StartPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<StartPartialUpdateData, void>({
+      path: `/worksession/${worksessionId}/start`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name VerifyPartialUpdate
+   * @request PATCH:/worksession/{worksession_id}/verify
+   */
+  verifyPartialUpdate = (worksessionId: number, data: VerifyPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<VerifyPartialUpdateData, void>({
+      path: `/worksession/${worksessionId}/verify`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Delete worksession record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name WorksessionDelete
+   * @summary Delete worksession record.
+   * @request DELETE:/worksession/{worksession_id}
+   */
+  worksessionDelete = (worksessionId: number, params: RequestParams = {}) =>
+    this.request<WorksessionDeleteData, void>({
+      path: `/worksession/${worksessionId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get worksession record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name WorksessionDetail
+   * @summary Get worksession record
+   * @request GET:/worksession/{worksession_id}
+   */
+  worksessionDetail = (worksessionId: number, params: RequestParams = {}) =>
+    this.request<WorksessionDetailResult, void>({
+      path: `/worksession/${worksessionId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit worksession record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name WorksessionPartialUpdate
+   * @summary Edit worksession record
+   * @request PATCH:/worksession/{worksession_id}
+   */
+  worksessionPartialUpdate = (
+    worksessionId: number,
+    data: WorksessionPartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<WorksessionPartialUpdateData, void>({
+      path: `/worksession/${worksessionId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all worksession records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name WorksessionList
+   * @summary Query all worksession records
+   * @request GET:/worksession
+   */
+  worksessionList = (params: RequestParams = {}) =>
+    this.request<WorksessionListData, void>({
+      path: `/worksession`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add worksession record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags worksession
+   * @name WorksessionCreate
+   * @summary Add worksession record
+   * @request POST:/worksession
+   */
+  worksessionCreate = (data: WorksessionCreatePayload, params: RequestParams = {}) =>
+    this.request<WorksessionCreateData, void>({
+      path: `/worksession`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/chef-connect/data-contracts.ts
+++ b/api/__generated__/chef-connect/data-contracts.ts
@@ -1,0 +1,2867 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type AdminlogDeleteData = object;
+
+export interface AdminlogDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  target_id?: number;
+  target_type?: string;
+  action?: string;
+  reason?: string;
+  /** @format uuid */
+  operator_id?: string | null;
+}
+
+export interface AdminlogPartialUpdatePayload {
+  /** @format int64 */
+  target_id?: number;
+  target_type?: string;
+  action?: string;
+  reason?: string;
+  /** @format uuid */
+  operator_id?: string | null;
+}
+
+export interface AdminlogPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  target_id?: number;
+  target_type?: string;
+  action?: string;
+  reason?: string;
+  /** @format uuid */
+  operator_id?: string | null;
+}
+
+export type AdminlogListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  target_id?: number;
+  target_type?: string;
+  action?: string;
+  reason?: string;
+  /** @format uuid */
+  operator_id?: string | null;
+}[];
+
+export interface AdminlogCreatePayload {
+  /** @format int64 */
+  target_id?: number;
+  target_type?: string;
+  action?: string;
+  reason?: string;
+  /** @format uuid */
+  operator_id?: string | null;
+}
+
+export interface AdminlogCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  target_id?: number;
+  target_type?: string;
+  action?: string;
+  reason?: string;
+  /** @format uuid */
+  operator_id?: string | null;
+}
+
+export type ByRestaurantDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+}[];
+
+export interface BySessionDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+  worksession?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format timestamptz */
+    check_in_time?: number;
+    /** @format timestamptz */
+    check_out_time?: number;
+    total_hours?: number;
+    location_data?: string;
+    status?:
+      | "SCHEDULED"
+      | "IN_PROGRESS"
+      | "CANCELED_BY_CHEF"
+      | "CANCELED_BY_RESTAURANT"
+      | "COMPLETED"
+      | "VERIFIED"
+      | "DISPUTE"
+      | "ESCALATED"
+      | "PAID"
+      | "CANCELED";
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    user_id?: string | null;
+    /** @format int64 */
+    restaurant_id?: number;
+    /** @format int64 */
+    job_id?: number;
+    /** @format int64 */
+    paid_amount?: number;
+    chef_feedback?: string;
+    restaurant_feedback?: string;
+    /** @format int64 */
+    chef_rating?: number;
+    /** @format int64 */
+    restaurant_rating?: number;
+  };
+  restaurant?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    cuisine_type?: string;
+    business_hours?: string;
+    contact_info?: string;
+    profile_image?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** Whether the restaurant is active. */
+    is_active?: boolean;
+    /** @format uuid */
+    companies_id?: string | null;
+    station?: string;
+    access?: string;
+    rating?: number;
+    /** @default "1" */
+    is_approved?: boolean;
+    cuisine_category?: number[] | null;
+  };
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+}
+
+export type ByUserDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+  restaurant?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    cuisine_type?: string;
+    business_hours?: string;
+    contact_info?: string;
+    profile_image?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** Whether the restaurant is active. */
+    is_active?: boolean;
+    /** @format uuid */
+    companies_id?: string | null;
+    station?: string;
+    access?: string;
+    rating?: number;
+    /** @default "1" */
+    is_approved?: boolean;
+    cuisine_category?: number[] | null;
+  };
+}[];
+
+export type ChefReviewDeleteData = object;
+
+export interface ChefReviewDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+}
+
+export interface ChefReviewPartialUpdatePayload {
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+}
+
+export interface ChefReviewPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+}
+
+export type ChefReviewListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+}[];
+
+export interface ChefReviewCreatePayload {
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+}
+
+export interface ChefReviewCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format uuid */
+  reviewer_id?: string;
+  /** @format int64 */
+  reviewee_id?: number;
+}
+
+export type FilesDeleteData = object;
+
+export interface FilesDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+}
+
+export interface FilesPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+}
+
+export type FilesListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+}[];
+
+export interface FilesCreateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+}
+
+export interface CompanyDetailData {
+  result1?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    phone?: string;
+    website?: string;
+    description?: string;
+    status?: "pending" | "approved" | "banned" | "rejected";
+    /** @format date */
+    updated_at?: string | null;
+    business_registration_number?: string;
+    logo_url?: string;
+  };
+  job?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+  }[];
+}
+
+export type RestaurantDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  title?: string;
+  description?: string;
+  /** @format date */
+  work_date?: string;
+  /** @format timestamptz */
+  start_time?: number;
+  /** @format timestamptz */
+  end_time?: number;
+  hourly_rate?: number;
+  required_skills?: string[];
+  status?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  restaurant_id?: number;
+  image?: string;
+  task?: string;
+  skill?: string;
+  whattotake?: string;
+  note?: string;
+  point?: string;
+  transportation?: string;
+  /** @default "1" */
+  is_approved?: boolean;
+}[];
+
+export type DeleteJobData = object;
+
+export interface GetJobData {
+  job?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+  };
+  restaurant?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    cuisine_type?: string;
+    business_hours?: string;
+    contact_info?: string;
+    profile_image?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** Whether the restaurant is active. */
+    is_active?: boolean;
+    /** @format uuid */
+    companies_id?: string | null;
+    station?: string;
+    access?: string;
+    rating?: number;
+    /** @default "1" */
+    is_approved?: boolean;
+    cuisine_category?: number[] | null;
+  };
+}
+
+export interface PatchJobPayload {
+  title?: string;
+  description?: string;
+  /** @format date */
+  work_date?: string;
+  /** @format timestamptz */
+  start_time?: number;
+  /** @format timestamptz */
+  end_time?: number;
+  hourly_rate?: number;
+  required_skills?: string[];
+  status?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  restaurant_id?: number;
+  image?: string;
+  task?: string;
+  skill?: string;
+  whattotake?: string;
+  note?: string;
+  point?: string;
+  transportation?: string;
+  /** @default "1" */
+  is_approved?: boolean;
+}
+
+export interface PatchJobData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  title?: string;
+  description?: string;
+  /** @format date */
+  work_date?: string;
+  /** @format timestamptz */
+  start_time?: number;
+  /** @format timestamptz */
+  end_time?: number;
+  hourly_rate?: number;
+  required_skills?: string[];
+  status?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  restaurant_id?: number;
+  image?: string;
+  task?: string;
+  skill?: string;
+  whattotake?: string;
+  note?: string;
+  point?: string;
+  transportation?: string;
+  /** @default "1" */
+  is_approved?: boolean;
+}
+
+export interface JobWithCheckCreatePayload {
+  title?: string;
+  description?: string;
+  /** @format date */
+  work_date?: string;
+  /** @format timestamptz */
+  start_time?: number;
+  /** @format timestamptz */
+  end_time?: number;
+  hourly_rate?: number;
+  required_skills?: string[];
+  status?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  restaurant_id?: number;
+  image?: string;
+  task?: string;
+  skill?: string;
+  whattotake?: string;
+  note?: string;
+  point?: string;
+  transportation?: string;
+  /** @default "1" */
+  is_approved?: boolean;
+}
+
+export interface JobWithCheckCreateData {
+  result1?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+  };
+  al?: string;
+}
+
+export interface GetJob2Data {
+  jobs?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+    restaurant?: {
+      /** @format int64 */
+      id?: number;
+      /**
+       * @format timestamptz
+       * @default "now"
+       */
+      created_at?: number;
+      name?: string;
+      address?: string;
+      cuisine_type?: string;
+      business_hours?: string;
+      contact_info?: string;
+      profile_image?: string;
+      /** @format timestamptz */
+      updated_at?: number;
+      /** Whether the restaurant is active. */
+      is_active?: boolean;
+      /** @format uuid */
+      companies_id?: string | null;
+      station?: string;
+      access?: string;
+      rating?: number;
+      /** @default "1" */
+      is_approved?: boolean;
+      cuisine_category?:
+        | {
+            "0"?: {
+              /** @format int64 */
+              id?: number;
+              /**
+               * @format timestamptz
+               * @default "now"
+               */
+              created_at?: number;
+              /** Whether this cuisine is the primary cuisine for the restaurant. */
+              is_primary?: boolean;
+              category?: string;
+            };
+          }[]
+        | null;
+    };
+  }[];
+}
+
+export interface PostJobPayload {
+  title?: string;
+  description?: string;
+  /** @format date */
+  work_date?: string;
+  /** @format timestamptz */
+  start_time?: number;
+  /** @format timestamptz */
+  end_time?: number;
+  hourly_rate?: number;
+  required_skills?: string[];
+  status?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  restaurant_id?: number;
+  image?: string;
+  task?: string;
+  skill?: string;
+  whattotake?: string;
+  note?: string;
+  point?: string;
+  transportation?: string;
+  /** @default "1" */
+  is_approved?: boolean;
+}
+
+export interface PostJobData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  title?: string;
+  description?: string;
+  /** @format date */
+  work_date?: string;
+  /** @format timestamptz */
+  start_time?: number;
+  /** @format timestamptz */
+  end_time?: number;
+  hourly_rate?: number;
+  required_skills?: string[];
+  status?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  restaurant_id?: number;
+  image?: string;
+  task?: string;
+  skill?: string;
+  whattotake?: string;
+  note?: string;
+  point?: string;
+  transportation?: string;
+  /** @default "1" */
+  is_approved?: boolean;
+}
+
+export type WorksessionDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  chef_id?: string;
+  sender_type?: "chef" | "restaurant";
+  /** @format int64 */
+  restaurant_id?: number | null;
+  /** @format int64 */
+  worksession_id?: number;
+}[];
+
+export type MessageDeleteData = object;
+
+export interface MessageDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  chef_id?: string;
+  sender_type?: "chef" | "restaurant";
+  /** @format int64 */
+  restaurant_id?: number | null;
+  /** @format int64 */
+  worksession_id?: number;
+}
+
+export interface MessagePartialUpdatePayload {
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  chef_id?: string;
+  sender_type?: "chef" | "restaurant";
+  /** @format int64 */
+  restaurant_id?: number | null;
+  /** @format int64 */
+  worksession_id?: number;
+}
+
+export interface MessagePartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  chef_id?: string;
+  sender_type?: "chef" | "restaurant";
+  /** @format int64 */
+  restaurant_id?: number | null;
+  /** @format int64 */
+  worksession_id?: number;
+}
+
+export type MessageattachmentDeleteData = object;
+
+export interface MessageattachmentDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  message_id?: number;
+  file_name?: string;
+  file_path?: string;
+  file_type?: string;
+  /** @format int64 */
+  file_size?: number;
+}
+
+export interface MessageattachmentPartialUpdatePayload {
+  /** @format int64 */
+  message_id?: number;
+  file_name?: string;
+  file_path?: string;
+  file_type?: string;
+  /** @format int64 */
+  file_size?: number;
+}
+
+export interface MessageattachmentPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  message_id?: number;
+  file_name?: string;
+  file_path?: string;
+  file_type?: string;
+  /** @format int64 */
+  file_size?: number;
+}
+
+export type MessageattachmentListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  message_id?: number;
+  file_name?: string;
+  file_path?: string;
+  file_type?: string;
+  /** @format int64 */
+  file_size?: number;
+}[];
+
+export interface MessageattachmentCreatePayload {
+  /** @format int64 */
+  message_id?: number;
+  file_name?: string;
+  file_path?: string;
+  file_type?: string;
+  /** @format int64 */
+  file_size?: number;
+}
+
+export interface MessageattachmentCreateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  message_id?: number;
+  file_name?: string;
+  file_path?: string;
+  file_type?: string;
+  /** @format int64 */
+  file_size?: number;
+}
+
+export type MessageListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  chef_id?: string;
+  sender_type?: "chef" | "restaurant";
+  /** @format int64 */
+  restaurant_id?: number | null;
+  /** @format int64 */
+  worksession_id?: number;
+}[];
+
+export interface MessageCreatePayload {
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  sender_type?: "chef" | "restaurant";
+  /** @format int64 */
+  restaurant_id?: number | null;
+  /** @format int64 */
+  worksession_id?: number;
+}
+
+export interface MessageCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  chef_id?: string;
+  sender_type?: "chef" | "restaurant";
+  /** @format int64 */
+  restaurant_id?: number | null;
+  /** @format int64 */
+  worksession_id?: number;
+}
+
+export type NotificationDeleteData = object;
+
+export interface NotificationDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  type?: "new_job" | "application_status" | "new_message" | "review" | "operator" | "payment";
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  user_id?: string;
+  /** url */
+  related_link?: string;
+}
+
+export interface NotificationPartialUpdatePayload {
+  type?: "new_job" | "application_status" | "new_message" | "review" | "operator" | "payment";
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  user_id?: string;
+  /** url */
+  related_link?: string;
+}
+
+export interface NotificationPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  type?: "new_job" | "application_status" | "new_message" | "review" | "operator" | "payment";
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  user_id?: string;
+  /** url */
+  related_link?: string;
+}
+
+export type NotificationListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  type?: "new_job" | "application_status" | "new_message" | "review" | "operator" | "payment";
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  user_id?: string;
+  /** url */
+  related_link?: string;
+}[];
+
+export interface NotificationCreatePayload {
+  type?: "new_job" | "application_status" | "new_message" | "review" | "operator" | "payment";
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  user_id?: string;
+  /** url */
+  related_link?: string;
+}
+
+export interface NotificationCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  type?: "new_job" | "application_status" | "new_message" | "review" | "operator" | "payment";
+  content?: string;
+  is_read?: boolean;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  user_id?: string;
+  /** url */
+  related_link?: string;
+}
+
+export type PaymentDeleteData = object;
+
+export interface PaymentDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  amount?: number;
+  status?: string;
+  /** @format date */
+  transaction_date?: string;
+  invoice_number?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+}
+
+export interface PaymentPartialUpdatePayload {
+  amount?: number;
+  status?: string;
+  /** @format date */
+  transaction_date?: string;
+  invoice_number?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+}
+
+export interface PaymentPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  amount?: number;
+  status?: string;
+  /** @format date */
+  transaction_date?: string;
+  invoice_number?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+}
+
+export type PaymentListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  amount?: number;
+  status?: string;
+  /** @format date */
+  transaction_date?: string;
+  invoice_number?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+}[];
+
+export interface PaymentCreatePayload {
+  amount?: number;
+  status?: string;
+  /** @format date */
+  transaction_date?: string;
+  invoice_number?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+}
+
+export interface PaymentCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  amount?: number;
+  status?: string;
+  /** @format date */
+  transaction_date?: string;
+  invoice_number?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+}
+
+export type PhotosDeleteData = object;
+
+export interface PhotosDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  photo?: {
+    /** @default "public" */
+    access?: "public" | "private";
+    path?: string;
+    name?: string;
+    type?: string;
+    /** @format int64 */
+    size?: number;
+    mime?: string;
+    meta?: object;
+    url?: string | null;
+  };
+}
+
+export interface PhotosPartialUpdatePayload {
+  photo?: {
+    /** @default "public" */
+    access?: "public" | "private";
+    path: string;
+    name: string;
+    type: string;
+    /** @format int64 */
+    size: number;
+    mime: string;
+    meta: object;
+  } | null;
+}
+
+export interface PhotosPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  photo?: {
+    /** @default "public" */
+    access?: "public" | "private";
+    path?: string;
+    name?: string;
+    type?: string;
+    /** @format int64 */
+    size?: number;
+    mime?: string;
+    meta?: object;
+    url?: string | null;
+  };
+}
+
+export type PhotosListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  photo?: {
+    /** @default "public" */
+    access?: "public" | "private";
+    path?: string;
+    name?: string;
+    type?: string;
+    /** @format int64 */
+    size?: number;
+    mime?: string;
+    meta?: object;
+    url?: string | null;
+  };
+}[];
+
+export interface PhotosCreatePayload {
+  /** @format binary */
+  image?: File | null;
+}
+
+export type PhotosCreateData = object;
+
+export type CompanyDetailResult = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  cuisine_type?: string;
+  business_hours?: string;
+  contact_info?: string;
+  profile_image?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** Whether the restaurant is active. */
+  is_active?: boolean;
+  /** @format uuid */
+  companies_id?: string | null;
+  station?: string;
+  access?: string;
+  rating?: number;
+  /** @default "1" */
+  is_approved?: boolean;
+  cuisine_category?: number[] | null;
+}[];
+
+export type RestaurantDeleteData = object;
+
+export interface RestaurantDetailResult {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  cuisine_type?: string;
+  business_hours?: string;
+  contact_info?: string;
+  profile_image?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** Whether the restaurant is active. */
+  is_active?: boolean;
+  /** @format uuid */
+  companies_id?: string | null;
+  station?: string;
+  access?: string;
+  rating?: number;
+  /** @default "1" */
+  is_approved?: boolean;
+  cuisine_category?: number[] | null;
+}
+
+export interface RestaurantPartialUpdatePayload {
+  name?: string;
+  address?: string;
+  cuisine_type?: string;
+  business_hours?: string;
+  contact_info?: string;
+  profile_image?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** Whether the restaurant is active. */
+  is_active?: boolean;
+  /** @format uuid */
+  companies_id?: string | null;
+  station?: string;
+  access?: string;
+  rating?: number;
+  /** @default "1" */
+  is_approved?: boolean;
+  cuisine_category?: number[] | null;
+}
+
+export interface RestaurantPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  cuisine_type?: string;
+  business_hours?: string;
+  contact_info?: string;
+  profile_image?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** Whether the restaurant is active. */
+  is_active?: boolean;
+  /** @format uuid */
+  companies_id?: string | null;
+  station?: string;
+  access?: string;
+  rating?: number;
+  /** @default "1" */
+  is_approved?: boolean;
+  cuisine_category?: number[] | null;
+}
+
+export type RestaurantCompanyDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  cuisine_type?: string;
+  business_hours?: string;
+  contact_info?: string;
+  profile_image?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** Whether the restaurant is active. */
+  is_active?: boolean;
+  /** @format uuid */
+  companies_id?: string | null;
+  station?: string;
+  access?: string;
+  rating?: number;
+  /** @default "1" */
+  is_approved?: boolean;
+  cuisine_category?: number[] | null;
+}[];
+
+export type RestaurantCuisineListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}[];
+
+export type RestaurantJobDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  title?: string;
+  description?: string;
+  /** @format date */
+  work_date?: string;
+  /** @format timestamptz */
+  start_time?: number;
+  /** @format timestamptz */
+  end_time?: number;
+  hourly_rate?: number;
+  required_skills?: string[];
+  status?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  restaurant_id?: number;
+  image?: string;
+  task?: string;
+  skill?: string;
+  whattotake?: string;
+  note?: string;
+  point?: string;
+  transportation?: string;
+  /** @default "1" */
+  is_approved?: boolean;
+}[];
+
+export type ByChefDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+  restaurant?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    cuisine_type?: string;
+    business_hours?: string;
+    contact_info?: string;
+    profile_image?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** Whether the restaurant is active. */
+    is_active?: boolean;
+    /** @format uuid */
+    companies_id?: string | null;
+    station?: string;
+    access?: string;
+    rating?: number;
+    /** @default "1" */
+    is_approved?: boolean;
+    cuisine_category?: number[] | null;
+  };
+}[];
+
+export type ByRestaurantDetailResult = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+}[];
+
+export interface BySessionDetailResult {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+  worksession?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format timestamptz */
+    check_in_time?: number;
+    /** @format timestamptz */
+    check_out_time?: number;
+    total_hours?: number;
+    location_data?: string;
+    status?:
+      | "SCHEDULED"
+      | "IN_PROGRESS"
+      | "CANCELED_BY_CHEF"
+      | "CANCELED_BY_RESTAURANT"
+      | "COMPLETED"
+      | "VERIFIED"
+      | "DISPUTE"
+      | "ESCALATED"
+      | "PAID"
+      | "CANCELED";
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    user_id?: string | null;
+    /** @format int64 */
+    restaurant_id?: number;
+    /** @format int64 */
+    job_id?: number;
+    /** @format int64 */
+    paid_amount?: number;
+    chef_feedback?: string;
+    restaurant_feedback?: string;
+    /** @format int64 */
+    chef_rating?: number;
+    /** @format int64 */
+    restaurant_rating?: number;
+  };
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+  restaurant?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    cuisine_type?: string;
+    business_hours?: string;
+    contact_info?: string;
+    profile_image?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** Whether the restaurant is active. */
+    is_active?: boolean;
+    /** @format uuid */
+    companies_id?: string | null;
+    station?: string;
+    access?: string;
+    rating?: number;
+    /** @default "1" */
+    is_approved?: boolean;
+    cuisine_category?: number[] | null;
+  };
+}
+
+export type RestaurantReviewDeleteData = object;
+
+export interface RestaurantReviewDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+}
+
+export interface RestaurantReviewPartialUpdatePayload {
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+}
+
+export interface RestaurantReviewPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+}
+
+export type RestaurantReviewListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+}[];
+
+export interface RestaurantReviewCreatePayload {
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+}
+
+export interface RestaurantReviewCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format int64 */
+  rating?: number;
+  comment?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format int64 */
+  session_id?: number;
+  /** @format int64 */
+  reviewer_id?: number;
+  /** @format uuid */
+  reviewee_id?: string;
+}
+
+export type RestaurantListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  cuisine_type?: string;
+  business_hours?: string;
+  contact_info?: string;
+  profile_image?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** Whether the restaurant is active. */
+  is_active?: boolean;
+  /** @format uuid */
+  companies_id?: string | null;
+  station?: string;
+  access?: string;
+  rating?: number;
+  /** @default "1" */
+  is_approved?: boolean;
+  cuisine_category?:
+    | {
+        "0"?: {
+          /** @format int64 */
+          id?: number;
+          /**
+           * @format timestamptz
+           * @default "now"
+           */
+          created_at?: number;
+          /** Whether this cuisine is the primary cuisine for the restaurant. */
+          is_primary?: boolean;
+          category?: string;
+        };
+      }[]
+    | null;
+}[];
+
+export interface RestaurantCreatePayload {
+  name?: string;
+  address?: string;
+  cuisine_type?: string;
+  business_hours?: string;
+  contact_info?: string;
+  profile_image?: string;
+  /** @format timestamptz */
+  updated_at?: number;
+  /** Whether the restaurant is active. */
+  is_active?: boolean;
+  /** @format uuid */
+  companies_id?: string | null;
+  station?: string;
+  access?: string;
+  rating?: number;
+  /** @default "1" */
+  is_approved?: boolean;
+  cuisine_category?: number[] | null;
+  /** @format binary */
+  photo?: File | null;
+}
+
+export type RestaurantCreateData = object;
+
+export type UserDeleteData = object;
+
+export interface UserDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  user_type?: string;
+  status?: string;
+  /** @format date */
+  last_login_at?: string | null;
+  /** @format date */
+  updated_at?: string | null;
+  skills?: string[];
+  experience_level?: string;
+  bio?: string;
+  certifications?: string[];
+  /** @format date */
+  dateofbirth?: string | null;
+  profile_image?: string;
+  is_approved?: boolean;
+}
+
+export interface UserPartialUpdatePayload {
+  name?: string;
+  /** @format email */
+  email?: string;
+  user_type?: string;
+  status?: string;
+  /** @format date */
+  last_login_at?: string | null;
+  /** @format date */
+  updated_at?: string | null;
+  skills?: string[];
+  experience_level?: string;
+  bio?: string;
+  certifications?: string[];
+  /** @format date */
+  dateofbirth?: string | null;
+  profile_image?: string;
+  is_approved?: boolean;
+  /** @format binary */
+  photo?: File | null;
+}
+
+export type UserPartialUpdateData = object;
+
+export type UserListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  user_type?: string;
+  status?: string;
+  /** @format date */
+  last_login_at?: string | null;
+  /** @format date */
+  updated_at?: string | null;
+  skills?: string[];
+  experience_level?: string;
+  bio?: string;
+  certifications?: string[];
+  /** @format date */
+  dateofbirth?: string | null;
+  profile_image?: string;
+  is_approved?: boolean;
+}[];
+
+export interface UserCreatePayload {
+  name?: string;
+  /** @format email */
+  email?: string;
+  user_type?: string;
+  status?: string;
+  /** @format date */
+  last_login_at?: string | null;
+  /** @format date */
+  updated_at?: string | null;
+  skills?: string[];
+  experience_level?: string;
+  bio?: string;
+  certifications?: string[];
+  /** @format date */
+  dateofbirth?: string | null;
+  profile_image?: string;
+  is_approved?: boolean;
+}
+
+export interface UserCreateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  user_type?: string;
+  status?: string;
+  /** @format date */
+  last_login_at?: string | null;
+  /** @format date */
+  updated_at?: string | null;
+  skills?: string[];
+  experience_level?: string;
+  bio?: string;
+  certifications?: string[];
+  /** @format date */
+  dateofbirth?: string | null;
+  profile_image?: string;
+  is_approved?: boolean;
+}
+
+export interface ApplicationDetailParams {
+  user_id?: string;
+  applicationId: string;
+}
+
+export interface ApplicationDetailData {
+  result1?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format timestamptz */
+    check_in_time?: number;
+    /** @format timestamptz */
+    check_out_time?: number;
+    total_hours?: number;
+    location_data?: string;
+    status?:
+      | "SCHEDULED"
+      | "IN_PROGRESS"
+      | "CANCELED_BY_CHEF"
+      | "CANCELED_BY_RESTAURANT"
+      | "COMPLETED"
+      | "VERIFIED"
+      | "DISPUTE"
+      | "ESCALATED"
+      | "PAID"
+      | "CANCELED";
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    user_id?: string | null;
+    /** @format int64 */
+    restaurant_id?: number;
+    /** @format int64 */
+    job_id?: number;
+    /** @format int64 */
+    paid_amount?: number;
+    chef_feedback?: string;
+    restaurant_feedback?: string;
+    /** @format int64 */
+    chef_rating?: number;
+    /** @format int64 */
+    restaurant_rating?: number;
+  };
+  messages?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    content?: string;
+    is_read?: boolean;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    chef_id?: string;
+    sender_type?: "chef" | "restaurant";
+    /** @format int64 */
+    restaurant_id?: number | null;
+    /** @format int64 */
+    worksession_id?: number;
+  }[];
+}
+
+export type RestaurantTodoDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+  job?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+  } | null;
+}[];
+
+export type UserTodoDetailData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+  job?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+    restaurant?: {
+      /** @format int64 */
+      id?: number;
+      /**
+       * @format timestamptz
+       * @default "now"
+       */
+      created_at?: number;
+      name?: string;
+      address?: string;
+      cuisine_type?: string;
+      business_hours?: string;
+      contact_info?: string;
+      profile_image?: string;
+      /** @format timestamptz */
+      updated_at?: number;
+      /** Whether the restaurant is active. */
+      is_active?: boolean;
+      /** @format uuid */
+      companies_id?: string | null;
+      station?: string;
+      access?: string;
+      rating?: number;
+      /** @default "1" */
+      is_approved?: boolean;
+      cuisine_category?: number[] | null;
+    };
+  };
+}[];
+
+export interface FinishPartialUpdatePayload {
+  /** @format int64 */
+  rating?: number;
+  feedback?: string;
+  /** @format timestamptz */
+  check_out_time?: number | null;
+}
+
+export interface FinishPartialUpdateData {
+  result1?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format timestamptz */
+    check_in_time?: number;
+    /** @format timestamptz */
+    check_out_time?: number;
+    total_hours?: number;
+    location_data?: string;
+    status?:
+      | "SCHEDULED"
+      | "IN_PROGRESS"
+      | "CANCELED_BY_CHEF"
+      | "CANCELED_BY_RESTAURANT"
+      | "COMPLETED"
+      | "VERIFIED"
+      | "DISPUTE"
+      | "ESCALATED"
+      | "PAID"
+      | "CANCELED";
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    user_id?: string | null;
+    /** @format int64 */
+    restaurant_id?: number;
+    /** @format int64 */
+    job_id?: number;
+    /** @format int64 */
+    paid_amount?: number;
+    chef_feedback?: string;
+    restaurant_feedback?: string;
+    /** @format int64 */
+    chef_rating?: number;
+    /** @format int64 */
+    restaurant_rating?: number;
+  };
+  review?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format int64 */
+    rating?: number;
+    comment?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    session_id?: number;
+    /** @format uuid */
+    reviewer_id?: string;
+    /** @format int64 */
+    reviewee_id?: number;
+  };
+}
+
+export interface StartPartialUpdatePayload {
+  /** @format timestamptz */
+  check_in_time?: number | null;
+}
+
+export interface StartPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+}
+
+export interface VerifyPartialUpdatePayload {
+  /** @format int64 */
+  rating?: number;
+  feedback?: string;
+}
+
+export interface VerifyPartialUpdateData {
+  result1?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format timestamptz */
+    check_in_time?: number;
+    /** @format timestamptz */
+    check_out_time?: number;
+    total_hours?: number;
+    location_data?: string;
+    status?:
+      | "SCHEDULED"
+      | "IN_PROGRESS"
+      | "CANCELED_BY_CHEF"
+      | "CANCELED_BY_RESTAURANT"
+      | "COMPLETED"
+      | "VERIFIED"
+      | "DISPUTE"
+      | "ESCALATED"
+      | "PAID"
+      | "CANCELED";
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format uuid */
+    application_id?: string;
+    /** @format uuid */
+    user_id?: string | null;
+    /** @format int64 */
+    restaurant_id?: number;
+    /** @format int64 */
+    job_id?: number;
+    /** @format int64 */
+    paid_amount?: number;
+    chef_feedback?: string;
+    restaurant_feedback?: string;
+    /** @format int64 */
+    chef_rating?: number;
+    /** @format int64 */
+    restaurant_rating?: number;
+  };
+  review?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format int64 */
+    rating?: number;
+    comment?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    session_id?: number;
+    /** @format int64 */
+    reviewer_id?: number;
+    /** @format uuid */
+    reviewee_id?: string;
+  };
+}
+
+export type WorksessionDeleteData = object;
+
+export interface WorksessionDetailResult {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+}
+
+export interface WorksessionPartialUpdatePayload {
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+}
+
+export interface WorksessionPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+}
+
+export type WorksessionListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+}[];
+
+export interface WorksessionCreatePayload {
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+}
+
+export interface WorksessionCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format timestamptz */
+  check_in_time?: number;
+  /** @format timestamptz */
+  check_out_time?: number;
+  total_hours?: number;
+  location_data?: string;
+  status?:
+    | "SCHEDULED"
+    | "IN_PROGRESS"
+    | "CANCELED_BY_CHEF"
+    | "CANCELED_BY_RESTAURANT"
+    | "COMPLETED"
+    | "VERIFIED"
+    | "DISPUTE"
+    | "ESCALATED"
+    | "PAID"
+    | "CANCELED";
+  /** @format timestamptz */
+  updated_at?: number;
+  /** @format uuid */
+  application_id?: string;
+  /** @format uuid */
+  user_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  /** @format int64 */
+  job_id?: number;
+  /** @format int64 */
+  paid_amount?: number;
+  chef_feedback?: string;
+  restaurant_feedback?: string;
+  /** @format int64 */
+  chef_rating?: number;
+  /** @format int64 */
+  restaurant_rating?: number;
+}

--- a/api/__generated__/chef-connect/http-client.ts
+++ b/api/__generated__/chef-connect/http-client.ts
@@ -1,0 +1,146 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  axiosInstance: AxiosInstance;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public instance: AxiosInstance;
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private secure?: boolean;
+  private format?: ResponseType;
+
+  constructor({ axiosInstance, securityWorker, secure, format, ...axiosConfig }: ApiConfig<SecurityDataType> = {}) {
+    this.instance = axiosInstance;
+    this.instance.defaults.baseURL = "https://xcti-onox-8bdw.n7e.xano.io/api:Mv5jTolf";
+    this.secure = secure;
+    this.format = format;
+    this.securityWorker = securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected mergeRequestParams(params1: AxiosRequestConfig, params2?: AxiosRequestConfig): AxiosRequestConfig {
+    const method = params1.method || (params2 && params2.method);
+
+    return {
+      ...this.instance.defaults,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...((method && this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected stringifyFormItem(formItem: unknown) {
+    if (typeof formItem === "object" && formItem !== null) {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
+  protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
+    return Object.keys(input || {}).reduce((formData, key) => {
+      const property = input[key];
+      const propertyContent: any[] = property instanceof Array ? property : [property];
+
+      for (const formItem of propertyContent) {
+        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
+      }
+
+      return formData;
+    }, new FormData());
+  }
+
+  public request = async <T = any, _E = any>({
+    secure,
+    path,
+    type,
+    query,
+    format,
+    body,
+    ...params
+  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const responseFormat = format || this.format || undefined;
+
+    if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
+      body = this.createFormData(body as Record<string, unknown>);
+    }
+
+    if (type === ContentType.Text && body && body !== null && typeof body !== "string") {
+      body = JSON.stringify(body);
+    }
+
+    return this.instance.request({
+      ...requestParams,
+      headers: {
+        ...(requestParams.headers || {}),
+        ...(type ? { "Content-Type": type } : {}),
+      },
+      params: query,
+      responseType: responseFormat,
+      data: body,
+      url: path,
+    });
+  };
+}

--- a/api/__generated__/company/Auth.ts
+++ b/api/__generated__/company/Auth.ts
@@ -1,0 +1,74 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  GetAuthData,
+  LoginCreateData,
+  LoginCreatePayload,
+  SignupCreateData,
+  SignupCreatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Auth<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Login and retrieve an authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags auth
+   * @name LoginCreate
+   * @summary Login and retrieve an authentication token
+   * @request POST:/auth/login
+   */
+  loginCreate = (data: LoginCreatePayload, params: RequestParams = {}) =>
+    this.request<LoginCreateData, void>({
+      path: `/auth/login`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get the record belonging to the authentication token <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags auth
+   * @name GetAuth
+   * @summary Get the record belonging to the authentication token
+   * @request GET:/auth/me
+   * @secure
+   */
+  getAuth = (params: RequestParams = {}) =>
+    this.request<GetAuthData, void>({
+      path: `/auth/me`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Signup and retrieve an authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags auth
+   * @name SignupCreate
+   * @summary Signup and retrieve an authentication token
+   * @request POST:/auth/signup
+   */
+  signupCreate = (data: SignupCreatePayload, params: RequestParams = {}) =>
+    this.request<SignupCreateData, void>({
+      path: `/auth/signup`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/Companies.ts
+++ b/api/__generated__/company/Companies.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  CompaniesCreateData,
+  CompaniesCreatePayload,
+  CompaniesDeleteData,
+  CompaniesDetailData,
+  CompaniesListData,
+  CompaniesPartialUpdateData,
+  CompaniesPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Companies<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete Companies record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companies
+   * @name CompaniesDelete
+   * @summary Delete Companies record.
+   * @request DELETE:/companies/{companies_id}
+   */
+  companiesDelete = (companiesId: string, params: RequestParams = {}) =>
+    this.request<CompaniesDeleteData, void>({
+      path: `/companies/${companiesId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get Companies record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companies
+   * @name CompaniesDetail
+   * @summary Get Companies record
+   * @request GET:/companies/{companies_id}
+   */
+  companiesDetail = (companiesId: string, params: RequestParams = {}) =>
+    this.request<CompaniesDetailData, void>({
+      path: `/companies/${companiesId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit Companies record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companies
+   * @name CompaniesPartialUpdate
+   * @summary Edit Companies record
+   * @request PATCH:/companies/{companies_id}
+   */
+  companiesPartialUpdate = (companiesId: string, data: CompaniesPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<CompaniesPartialUpdateData, void>({
+      path: `/companies/${companiesId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all Companies records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companies
+   * @name CompaniesList
+   * @summary Query all Companies records
+   * @request GET:/companies
+   */
+  companiesList = (params: RequestParams = {}) =>
+    this.request<CompaniesListData, void>({
+      path: `/companies`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add Companies record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companies
+   * @name CompaniesCreate
+   * @summary Add Companies record
+   * @request POST:/companies
+   */
+  companiesCreate = (data: CompaniesCreatePayload, params: RequestParams = {}) =>
+    this.request<CompaniesCreateData, void>({
+      path: `/companies`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/Company.ts
+++ b/api/__generated__/company/Company.ts
@@ -1,0 +1,34 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import { SignupCreateBody, SignupCreateResult } from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Company<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Signup and retrieve an authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags company
+   * @name SignupCreate
+   * @summary Signup and retrieve an authentication token
+   * @request POST:/company/signup
+   */
+  signupCreate = (data: SignupCreateBody, params: RequestParams = {}) =>
+    this.request<SignupCreateResult, void>({
+      path: `/company/signup`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/Companystaffs.ts
+++ b/api/__generated__/company/Companystaffs.ts
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  CompanystaffsCreateData,
+  CompanystaffsDeleteData,
+  CompanystaffsDetailData,
+  CompanystaffsListData,
+  CompanystaffsPartialUpdateData,
+} from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class Companystaffs<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete CompanyStaffs record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companystaffs
+   * @name CompanystaffsDelete
+   * @summary Delete CompanyStaffs record.
+   * @request DELETE:/companystaffs/{companystaffs_id}
+   */
+  companystaffsDelete = (companystaffsId: string, params: RequestParams = {}) =>
+    this.request<CompanystaffsDeleteData, void>({
+      path: `/companystaffs/${companystaffsId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get CompanyStaffs record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companystaffs
+   * @name CompanystaffsDetail
+   * @summary Get CompanyStaffs record
+   * @request GET:/companystaffs/{companystaffs_id}
+   */
+  companystaffsDetail = (companystaffsId: string, params: RequestParams = {}) =>
+    this.request<CompanystaffsDetailData, void>({
+      path: `/companystaffs/${companystaffsId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit CompanyStaffs record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companystaffs
+   * @name CompanystaffsPartialUpdate
+   * @summary Edit CompanyStaffs record
+   * @request PATCH:/companystaffs/{companystaffs_id}
+   */
+  companystaffsPartialUpdate = (companystaffsId: string, params: RequestParams = {}) =>
+    this.request<CompanystaffsPartialUpdateData, void>({
+      path: `/companystaffs/${companystaffsId}`,
+      method: "PATCH",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all CompanyStaffs records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companystaffs
+   * @name CompanystaffsList
+   * @summary Query all CompanyStaffs records
+   * @request GET:/companystaffs
+   */
+  companystaffsList = (params: RequestParams = {}) =>
+    this.request<CompanystaffsListData, void>({
+      path: `/companystaffs`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add CompanyStaffs record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companystaffs
+   * @name CompanystaffsCreate
+   * @summary Add CompanyStaffs record
+   * @request POST:/companystaffs
+   */
+  companystaffsCreate = (params: RequestParams = {}) =>
+    this.request<CompanystaffsCreateData, void>({
+      path: `/companystaffs`,
+      method: "POST",
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/Companyuser.ts
+++ b/api/__generated__/company/Companyuser.ts
@@ -1,0 +1,140 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  CompanyDetailData,
+  CompanyuserCreateData,
+  CompanyuserCreatePayload,
+  CompanyuserDeleteData,
+  CompanyuserDetailData,
+  CompanyuserListData,
+  CompanyuserPartialUpdateData,
+  CompanyuserPartialUpdatePayload,
+  MeRestaurantsListData,
+  MeRestaurantsListParams,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Companyuser<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companyuser
+   * @name CompanyDetail
+   * @request GET:/companyuser/company/{company_id}
+   */
+  companyDetail = (companyId: string, params: RequestParams = {}) =>
+    this.request<CompanyDetailData, void>({
+      path: `/companyuser/company/${companyId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companyuser
+   * @name MeRestaurantsList
+   * @request GET:/companyuser/me/restaurants
+   */
+  meRestaurantsList = (query: MeRestaurantsListParams, params: RequestParams = {}) =>
+    this.request<MeRestaurantsListData, void>({
+      path: `/companyuser/me/restaurants`,
+      method: "GET",
+      query: query,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Delete CompanyUser record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companyuser
+   * @name CompanyuserDelete
+   * @summary Delete CompanyUser record.
+   * @request DELETE:/companyuser/{companyuser_id}
+   */
+  companyuserDelete = (companyuserId: string, params: RequestParams = {}) =>
+    this.request<CompanyuserDeleteData, void>({
+      path: `/companyuser/${companyuserId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get CompanyUser record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companyuser
+   * @name CompanyuserDetail
+   * @summary Get CompanyUser record
+   * @request GET:/companyuser/{companyuser_id}
+   */
+  companyuserDetail = (companyuserId: string, params: RequestParams = {}) =>
+    this.request<CompanyuserDetailData, void>({
+      path: `/companyuser/${companyuserId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit CompanyUser record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companyuser
+   * @name CompanyuserPartialUpdate
+   * @summary Edit CompanyUser record
+   * @request PATCH:/companyuser/{companyuser_id}
+   */
+  companyuserPartialUpdate = (
+    companyuserId: string,
+    data: CompanyuserPartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<CompanyuserPartialUpdateData, void>({
+      path: `/companyuser/${companyuserId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all CompanyUser records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companyuser
+   * @name CompanyuserList
+   * @summary Query all CompanyUser records
+   * @request GET:/companyuser
+   */
+  companyuserList = (params: RequestParams = {}) =>
+    this.request<CompanyuserListData, void>({
+      path: `/companyuser`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add CompanyUser record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags companyuser
+   * @name CompanyuserCreate
+   * @summary Add CompanyUser record
+   * @request POST:/companyuser
+   */
+  companyuserCreate = (data: CompanyuserCreatePayload, params: RequestParams = {}) =>
+    this.request<CompanyuserCreateData, void>({
+      path: `/companyuser`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/Restaurant.ts
+++ b/api/__generated__/company/Restaurant.ts
@@ -1,0 +1,69 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  CheckAccessListData,
+  CheckAccessListParams,
+  CompanyusersListData,
+  CompanyusersListParams,
+  StaffsListData,
+  StaffsListParams,
+} from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class Restaurant<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name CheckAccessList
+   * @request GET:/restaurant/check-access
+   */
+  checkAccessList = (query: CheckAccessListParams, params: RequestParams = {}) =>
+    this.request<CheckAccessListData, void>({
+      path: `/restaurant/check-access`,
+      method: "GET",
+      query: query,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name CompanyusersList
+   * @request GET:/restaurant/companyusers
+   */
+  companyusersList = (query: CompanyusersListParams, params: RequestParams = {}) =>
+    this.request<CompanyusersListData, void>({
+      path: `/restaurant/companyusers`,
+      method: "GET",
+      query: query,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant
+   * @name StaffsList
+   * @request GET:/restaurant/staffs
+   */
+  staffsList = (query: StaffsListParams, params: RequestParams = {}) =>
+    this.request<StaffsListData, void>({
+      path: `/restaurant/staffs`,
+      method: "GET",
+      query: query,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/Restaurantaccess.ts
+++ b/api/__generated__/company/Restaurantaccess.ts
@@ -1,0 +1,108 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  RestaurantaccessCreateData,
+  RestaurantaccessCreatePayload,
+  RestaurantaccessDeleteData,
+  RestaurantaccessDetailData,
+  RestaurantaccessListData,
+  RestaurantaccessPartialUpdateData,
+  RestaurantaccessPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Restaurantaccess<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete RestaurantAccess record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurantaccess
+   * @name RestaurantaccessDelete
+   * @summary Delete RestaurantAccess record.
+   * @request DELETE:/restaurantaccess/{restaurantaccess_id}
+   */
+  restaurantaccessDelete = (restaurantaccessId: string, params: RequestParams = {}) =>
+    this.request<RestaurantaccessDeleteData, void>({
+      path: `/restaurantaccess/${restaurantaccessId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get RestaurantAccess record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurantaccess
+   * @name RestaurantaccessDetail
+   * @summary Get RestaurantAccess record
+   * @request GET:/restaurantaccess/{restaurantaccess_id}
+   */
+  restaurantaccessDetail = (restaurantaccessId: string, params: RequestParams = {}) =>
+    this.request<RestaurantaccessDetailData, void>({
+      path: `/restaurantaccess/${restaurantaccessId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit RestaurantAccess record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurantaccess
+   * @name RestaurantaccessPartialUpdate
+   * @summary Edit RestaurantAccess record
+   * @request PATCH:/restaurantaccess/{restaurantaccess_id}
+   */
+  restaurantaccessPartialUpdate = (
+    restaurantaccessId: string,
+    data: RestaurantaccessPartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<RestaurantaccessPartialUpdateData, void>({
+      path: `/restaurantaccess/${restaurantaccessId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all RestaurantAccess records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurantaccess
+   * @name RestaurantaccessList
+   * @summary Query all RestaurantAccess records
+   * @request GET:/restaurantaccess
+   */
+  restaurantaccessList = (params: RequestParams = {}) =>
+    this.request<RestaurantaccessListData, void>({
+      path: `/restaurantaccess`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add RestaurantAccess record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurantaccess
+   * @name RestaurantaccessCreate
+   * @summary Add RestaurantAccess record
+   * @request POST:/restaurantaccess
+   */
+  restaurantaccessCreate = (data: RestaurantaccessCreatePayload, params: RequestParams = {}) =>
+    this.request<RestaurantaccessCreateData, void>({
+      path: `/restaurantaccess`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/Staffrestaurantaccess.ts
+++ b/api/__generated__/company/Staffrestaurantaccess.ts
@@ -1,0 +1,98 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  StaffrestaurantaccessCreateData,
+  StaffrestaurantaccessDeleteData,
+  StaffrestaurantaccessDetailData,
+  StaffrestaurantaccessListData,
+  StaffrestaurantaccessPartialUpdateData,
+} from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class Staffrestaurantaccess<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete StaffRestaurantAccess record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags staffrestaurantaccess
+   * @name StaffrestaurantaccessDelete
+   * @summary Delete StaffRestaurantAccess record.
+   * @request DELETE:/staffrestaurantaccess/{staffrestaurantaccess_id}
+   */
+  staffrestaurantaccessDelete = (staffrestaurantaccessId: string, params: RequestParams = {}) =>
+    this.request<StaffrestaurantaccessDeleteData, void>({
+      path: `/staffrestaurantaccess/${staffrestaurantaccessId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get StaffRestaurantAccess record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags staffrestaurantaccess
+   * @name StaffrestaurantaccessDetail
+   * @summary Get StaffRestaurantAccess record
+   * @request GET:/staffrestaurantaccess/{staffrestaurantaccess_id}
+   */
+  staffrestaurantaccessDetail = (staffrestaurantaccessId: string, params: RequestParams = {}) =>
+    this.request<StaffrestaurantaccessDetailData, void>({
+      path: `/staffrestaurantaccess/${staffrestaurantaccessId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit StaffRestaurantAccess record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags staffrestaurantaccess
+   * @name StaffrestaurantaccessPartialUpdate
+   * @summary Edit StaffRestaurantAccess record
+   * @request PATCH:/staffrestaurantaccess/{staffrestaurantaccess_id}
+   */
+  staffrestaurantaccessPartialUpdate = (staffrestaurantaccessId: string, params: RequestParams = {}) =>
+    this.request<StaffrestaurantaccessPartialUpdateData, void>({
+      path: `/staffrestaurantaccess/${staffrestaurantaccessId}`,
+      method: "PATCH",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all StaffRestaurantAccess records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags staffrestaurantaccess
+   * @name StaffrestaurantaccessList
+   * @summary Query all StaffRestaurantAccess records
+   * @request GET:/staffrestaurantaccess
+   */
+  staffrestaurantaccessList = (params: RequestParams = {}) =>
+    this.request<StaffrestaurantaccessListData, void>({
+      path: `/staffrestaurantaccess`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add StaffRestaurantAccess record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags staffrestaurantaccess
+   * @name StaffrestaurantaccessCreate
+   * @summary Add StaffRestaurantAccess record
+   * @request POST:/staffrestaurantaccess
+   */
+  staffrestaurantaccessCreate = (params: RequestParams = {}) =>
+    this.request<StaffrestaurantaccessCreateData, void>({
+      path: `/staffrestaurantaccess`,
+      method: "POST",
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/company/data-contracts.ts
+++ b/api/__generated__/company/data-contracts.ts
@@ -1,0 +1,608 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export interface LoginCreatePayload {
+  /** @format email */
+  email?: string;
+  password?: string;
+}
+
+export interface LoginCreateData {
+  authToken?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format uuid */
+    companies_id?: string | null;
+    name?: string;
+    /** @format email */
+    email?: string;
+    phone?: string | null;
+    /** @format password */
+    password?: string;
+    is_admin?: boolean;
+    is_active?: boolean;
+    is_verified?: boolean;
+    /** @format timestamptz */
+    updated_at?: number | null;
+  };
+}
+
+export interface GetAuthData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}
+
+export interface SignupCreatePayload {
+  name?: string;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+}
+
+export interface SignupCreateData {
+  authToken?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format uuid */
+    companies_id?: string | null;
+    name?: string;
+    /** @format email */
+    email?: string;
+    phone?: string | null;
+    /** @format password */
+    password?: string;
+    is_admin?: boolean;
+    is_active?: boolean;
+    is_verified?: boolean;
+    /** @format timestamptz */
+    updated_at?: number | null;
+  };
+}
+
+export type CompaniesDeleteData = object;
+
+export interface CompaniesDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  phone?: string;
+  website?: string;
+  description?: string;
+  status?: "pending" | "approved" | "banned" | "rejected";
+  /** @format date */
+  updated_at?: string | null;
+  business_registration_number?: string;
+  logo_url?: string;
+}
+
+export interface CompaniesPartialUpdatePayload {
+  name?: string;
+  address?: string;
+  phone?: string;
+  website?: string;
+  description?: string;
+  status?: "pending" | "approved" | "banned" | "rejected";
+  /** @format date */
+  updated_at?: string | null;
+  business_registration_number?: string;
+  logo_url?: string;
+}
+
+export interface CompaniesPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  phone?: string;
+  website?: string;
+  description?: string;
+  status?: "pending" | "approved" | "banned" | "rejected";
+  /** @format date */
+  updated_at?: string | null;
+  business_registration_number?: string;
+  logo_url?: string;
+}
+
+export type CompaniesListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  phone?: string;
+  website?: string;
+  description?: string;
+  status?: "pending" | "approved" | "banned" | "rejected";
+  /** @format date */
+  updated_at?: string | null;
+  business_registration_number?: string;
+  logo_url?: string;
+}[];
+
+export interface CompaniesCreatePayload {
+  name?: string;
+  address?: string;
+  phone?: string;
+  website?: string;
+  description?: string;
+  status?: "pending" | "approved" | "banned" | "rejected";
+  /** @format date */
+  updated_at?: string | null;
+  business_registration_number?: string;
+  logo_url?: string;
+}
+
+export interface CompaniesCreateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  address?: string;
+  phone?: string;
+  website?: string;
+  description?: string;
+  status?: "pending" | "approved" | "banned" | "rejected";
+  /** @format date */
+  updated_at?: string | null;
+  business_registration_number?: string;
+  logo_url?: string;
+}
+
+export interface SignupCreateBody {
+  name?: string;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  company_name?: string;
+  phone?: string;
+}
+
+export interface SignupCreateResult {
+  authToken?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format uuid */
+    companies_id?: string | null;
+    name?: string;
+    /** @format email */
+    email?: string;
+    phone?: string | null;
+    /** @format password */
+    password?: string;
+    is_admin?: boolean;
+    is_active?: boolean;
+    is_verified?: boolean;
+    /** @format timestamptz */
+    updated_at?: number | null;
+  };
+  company?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    phone?: string;
+    website?: string;
+    description?: string;
+    status?: "pending" | "approved" | "banned" | "rejected";
+    /** @format date */
+    updated_at?: string | null;
+    business_registration_number?: string;
+    logo_url?: string;
+  };
+}
+
+export type CompanystaffsDeleteData = object;
+
+export type CompanystaffsDetailData = object;
+
+export type CompanystaffsPartialUpdateData = object;
+
+export type CompanystaffsListData = object;
+
+export type CompanystaffsCreateData = object;
+
+export type CompanyDetailData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  /** @format password */
+  password?: string;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}[];
+
+export interface MeRestaurantsListParams {
+  companyuser_id?: string;
+}
+
+export interface MeRestaurantsListData {
+  result1?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format uuid */
+    companies_id?: string | null;
+    name?: string;
+    /** @format email */
+    email?: string;
+    phone?: string | null;
+    /** @format password */
+    password?: string;
+    is_admin?: boolean;
+    is_active?: boolean;
+    is_verified?: boolean;
+    /** @format timestamptz */
+    updated_at?: number | null;
+  };
+  rest?: string;
+}
+
+export type CompanyuserDeleteData = object;
+
+export interface CompanyuserDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  /** @format password */
+  password?: string;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}
+
+export interface CompanyuserPartialUpdatePayload {
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}
+
+export interface CompanyuserPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  /** @format password */
+  password?: string;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}
+
+export type CompanyuserListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  /** @format password */
+  password?: string;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}[];
+
+export interface CompanyuserCreatePayload {
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}
+
+export interface CompanyuserCreateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companies_id?: string | null;
+  name?: string;
+  /** @format email */
+  email?: string;
+  phone?: string | null;
+  /** @format password */
+  password?: string;
+  is_admin?: boolean;
+  is_active?: boolean;
+  is_verified?: boolean;
+  /** @format timestamptz */
+  updated_at?: number | null;
+}
+
+export interface CheckAccessListParams {
+  /** @format uuid */
+  companyUserId?: string;
+  /** @format int64 */
+  restaurantId?: number;
+}
+
+export interface CheckAccessListData {
+  check_result?: string;
+}
+
+export interface CompanyusersListParams {
+  /** @format int64 */
+  restaurant_id?: number;
+}
+
+export interface CompanyusersListData {
+  result1?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    phone?: string;
+    website?: string;
+    description?: string;
+    status?: "pending" | "approved" | "banned" | "rejected";
+    /** @format date */
+    updated_at?: string | null;
+    business_registration_number?: string;
+    logo_url?: string;
+  };
+  admin?: string;
+}
+
+export interface StaffsListParams {
+  /** @format int64 */
+  restaurant_id?: number;
+}
+
+export type StaffsListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companyuser_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  can_edit?: boolean;
+  can_manage_jobs?: boolean;
+  companyuser?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format uuid */
+    companies_id?: string | null;
+    name?: string;
+    /** @format email */
+    email?: string;
+    phone?: string | null;
+    is_admin?: boolean;
+    is_active?: boolean;
+    is_verified?: boolean;
+    /** @format timestamptz */
+    updated_at?: number | null;
+  };
+}[];
+
+export type RestaurantaccessDeleteData = object;
+
+export interface RestaurantaccessDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companyuser_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  can_edit?: boolean;
+  can_manage_jobs?: boolean;
+}
+
+export interface RestaurantaccessPartialUpdatePayload {
+  /** @format uuid */
+  companyuser_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  can_edit?: boolean;
+  can_manage_jobs?: boolean;
+}
+
+export interface RestaurantaccessPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companyuser_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  can_edit?: boolean;
+  can_manage_jobs?: boolean;
+}
+
+export type RestaurantaccessListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format uuid */
+  companyuser_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  can_edit?: boolean;
+  can_manage_jobs?: boolean;
+}[];
+
+export interface RestaurantaccessCreatePayload {
+  /** @format uuid */
+  companyuser_id?: string | null;
+  /** @format int64 */
+  restaurant_id?: number;
+  can_edit?: boolean;
+  can_manage_jobs?: boolean;
+  /** @format email */
+  staff_email?: string;
+}
+
+export type RestaurantaccessCreateData = object;
+
+export type StaffrestaurantaccessDeleteData = object;
+
+export type StaffrestaurantaccessDetailData = object;
+
+export type StaffrestaurantaccessPartialUpdateData = object;
+
+export type StaffrestaurantaccessListData = object;
+
+export type StaffrestaurantaccessCreateData = object;

--- a/api/__generated__/company/http-client.ts
+++ b/api/__generated__/company/http-client.ts
@@ -1,0 +1,146 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  axiosInstance: AxiosInstance;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public instance: AxiosInstance;
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private secure?: boolean;
+  private format?: ResponseType;
+
+  constructor({ axiosInstance, securityWorker, secure, format, ...axiosConfig }: ApiConfig<SecurityDataType> = {}) {
+    this.instance = axiosInstance;
+    this.instance.defaults.baseURL = "https://xcti-onox-8bdw.n7e.xano.io/api:3LZoUG6X";
+    this.secure = secure;
+    this.format = format;
+    this.securityWorker = securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected mergeRequestParams(params1: AxiosRequestConfig, params2?: AxiosRequestConfig): AxiosRequestConfig {
+    const method = params1.method || (params2 && params2.method);
+
+    return {
+      ...this.instance.defaults,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...((method && this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected stringifyFormItem(formItem: unknown) {
+    if (typeof formItem === "object" && formItem !== null) {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
+  protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
+    return Object.keys(input || {}).reduce((formData, key) => {
+      const property = input[key];
+      const propertyContent: any[] = property instanceof Array ? property : [property];
+
+      for (const formItem of propertyContent) {
+        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
+      }
+
+      return formData;
+    }, new FormData());
+  }
+
+  public request = async <T = any, _E = any>({
+    secure,
+    path,
+    type,
+    query,
+    format,
+    body,
+    ...params
+  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const responseFormat = format || this.format || undefined;
+
+    if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
+      body = this.createFormData(body as Record<string, unknown>);
+    }
+
+    if (type === ContentType.Text && body && body !== null && typeof body !== "string") {
+      body = JSON.stringify(body);
+    }
+
+    return this.instance.request({
+      ...requestParams,
+      headers: {
+        ...(requestParams.headers || {}),
+        ...(type ? { "Content-Type": type } : {}),
+      },
+      params: query,
+      responseType: responseFormat,
+      data: body,
+      url: path,
+    });
+  };
+}

--- a/api/__generated__/operator/Alert.ts
+++ b/api/__generated__/operator/Alert.ts
@@ -1,0 +1,104 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  AlertCreateData,
+  AlertCreatePayload,
+  AlertDeleteData,
+  AlertDetailData,
+  AlertListData,
+  AlertPartialUpdateData,
+  AlertPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Alert<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Delete alert record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags alert
+   * @name AlertDelete
+   * @summary Delete alert record.
+   * @request DELETE:/alert/{alert_id}
+   */
+  alertDelete = (alertId: number, params: RequestParams = {}) =>
+    this.request<AlertDeleteData, void>({
+      path: `/alert/${alertId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get alert record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags alert
+   * @name AlertDetail
+   * @summary Get alert record
+   * @request GET:/alert/{alert_id}
+   */
+  alertDetail = (alertId: number, params: RequestParams = {}) =>
+    this.request<AlertDetailData, void>({
+      path: `/alert/${alertId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit alert record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags alert
+   * @name AlertPartialUpdate
+   * @summary Edit alert record
+   * @request PATCH:/alert/{alert_id}
+   */
+  alertPartialUpdate = (alertId: number, data: AlertPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<AlertPartialUpdateData, void>({
+      path: `/alert/${alertId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all alert records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags alert
+   * @name AlertList
+   * @summary Query all alert records
+   * @request GET:/alert
+   */
+  alertList = (params: RequestParams = {}) =>
+    this.request<AlertListData, void>({
+      path: `/alert`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add alert record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags alert
+   * @name AlertCreate
+   * @summary Add alert record
+   * @request POST:/alert
+   */
+  alertCreate = (data: AlertCreatePayload, params: RequestParams = {}) =>
+    this.request<AlertCreateData, void>({
+      path: `/alert`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/operator/Auth.ts
+++ b/api/__generated__/operator/Auth.ts
@@ -1,0 +1,74 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  GetAuthData,
+  LoginCreateData,
+  LoginCreatePayload,
+  SignupCreateData,
+  SignupCreatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Auth<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description Login and retrieve an authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags auth
+   * @name LoginCreate
+   * @summary Login and retrieve an authentication token
+   * @request POST:/auth/login
+   */
+  loginCreate = (data: LoginCreatePayload, params: RequestParams = {}) =>
+    this.request<LoginCreateData, void>({
+      path: `/auth/login`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get the record belonging to the authentication token <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags auth
+   * @name GetAuth
+   * @summary Get the record belonging to the authentication token
+   * @request GET:/auth/me
+   * @secure
+   */
+  getAuth = (params: RequestParams = {}) =>
+    this.request<GetAuthData, void>({
+      path: `/auth/me`,
+      method: "GET",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Signup and retrieve an authentication token <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags auth
+   * @name SignupCreate
+   * @summary Signup and retrieve an authentication token
+   * @request POST:/auth/signup
+   */
+  signupCreate = (data: SignupCreatePayload, params: RequestParams = {}) =>
+    this.request<SignupCreateData, void>({
+      path: `/auth/signup`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/operator/ChefSkill.ts
+++ b/api/__generated__/operator/ChefSkill.ts
@@ -1,0 +1,119 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  ChefSkillCreateData,
+  ChefSkillCreatePayload,
+  ChefSkillDeleteData,
+  ChefSkillDetailData,
+  ChefSkillListData,
+  ChefSkillPartialUpdateData,
+  ChefSkillPartialUpdatePayload,
+  ChefSkillUpdateData,
+  ChefSkillUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class ChefSkill<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_skill
+   * @name ChefSkillDelete
+   * @request DELETE:/chef_skill/{chef_skill_id}
+   */
+  chefSkillDelete = (chefSkillId: number, params: RequestParams = {}) =>
+    this.request<ChefSkillDeleteData, void>({
+      path: `/chef_skill/${chefSkillId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_skill
+   * @name ChefSkillDetail
+   * @request GET:/chef_skill/{chef_skill_id}
+   */
+  chefSkillDetail = (chefSkillId: number, params: RequestParams = {}) =>
+    this.request<ChefSkillDetailData, void>({
+      path: `/chef_skill/${chefSkillId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_skill
+   * @name ChefSkillPartialUpdate
+   * @request PATCH:/chef_skill/{chef_skill_id}
+   */
+  chefSkillPartialUpdate = (chefSkillId: number, data: ChefSkillPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<ChefSkillPartialUpdateData, void>({
+      path: `/chef_skill/${chefSkillId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_skill
+   * @name ChefSkillUpdate
+   * @request PUT:/chef_skill/{chef_skill_id}
+   */
+  chefSkillUpdate = (chefSkillId: number, data: ChefSkillUpdatePayload, params: RequestParams = {}) =>
+    this.request<ChefSkillUpdateData, void>({
+      path: `/chef_skill/${chefSkillId}`,
+      method: "PUT",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags chef_skill
+   * @name ChefSkillList
+   * @request GET:/chef_skill
+   */
+  chefSkillList = (params: RequestParams = {}) =>
+    this.request<ChefSkillListData, void>({
+      path: `/chef_skill`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags chef_skill
+   * @name ChefSkillCreate
+   * @request POST:/chef_skill
+   * @secure
+   */
+  chefSkillCreate = (data: ChefSkillCreatePayload, params: RequestParams = {}) =>
+    this.request<ChefSkillCreateData, void>({
+      path: `/chef_skill`,
+      method: "POST",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/operator/Operator.ts
+++ b/api/__generated__/operator/Operator.ts
@@ -1,0 +1,224 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  JobApprovePartialUpdateData,
+  JobApprovePartialUpdatePayload,
+  JobBanPartialUpdateData,
+  JobBanPartialUpdatePayload,
+  OperatorCreateData,
+  OperatorCreatePayload,
+  OperatorDeleteData,
+  OperatorDetailData,
+  OperatorListData,
+  OperatorPartialUpdateData,
+  OperatorPartialUpdatePayload,
+  RestaurantApprovePartialUpdateData,
+  RestaurantApprovePartialUpdatePayload,
+  RestaurantBanPartialUpdateData,
+  RestaurantBanPartialUpdatePayload,
+  UserApprovePartialUpdateData,
+  UserApprovePartialUpdatePayload,
+  UserBanPartialUpdateData,
+  UserBanPartialUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Operator<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags operator
+   * @name JobApprovePartialUpdate
+   * @request PATCH:/operator/job/approve
+   * @secure
+   */
+  jobApprovePartialUpdate = (data: JobApprovePartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<JobApprovePartialUpdateData, void>({
+      path: `/operator/job/approve`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags operator
+   * @name JobBanPartialUpdate
+   * @request PATCH:/operator/job/ban
+   * @secure
+   */
+  jobBanPartialUpdate = (data: JobBanPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<JobBanPartialUpdateData, void>({
+      path: `/operator/job/ban`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags operator
+   * @name RestaurantApprovePartialUpdate
+   * @request PATCH:/operator/restaurant/approve
+   * @secure
+   */
+  restaurantApprovePartialUpdate = (data: RestaurantApprovePartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<RestaurantApprovePartialUpdateData, void>({
+      path: `/operator/restaurant/approve`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags operator
+   * @name RestaurantBanPartialUpdate
+   * @request PATCH:/operator/restaurant/ban
+   * @secure
+   */
+  restaurantBanPartialUpdate = (data: RestaurantBanPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<RestaurantBanPartialUpdateData, void>({
+      path: `/operator/restaurant/ban`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags operator
+   * @name UserApprovePartialUpdate
+   * @request PATCH:/operator/user/approve
+   * @secure
+   */
+  userApprovePartialUpdate = (data: UserApprovePartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<UserApprovePartialUpdateData, void>({
+      path: `/operator/user/approve`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags operator
+   * @name UserBanPartialUpdate
+   * @request PATCH:/operator/user/ban
+   * @secure
+   */
+  userBanPartialUpdate = (data: UserBanPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<UserBanPartialUpdateData, void>({
+      path: `/operator/user/ban`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Delete Operator record. <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags operator
+   * @name OperatorDelete
+   * @summary Delete Operator record.
+   * @request DELETE:/operator/{operator_id}
+   */
+  operatorDelete = (operatorId: string, params: RequestParams = {}) =>
+    this.request<OperatorDeleteData, void>({
+      path: `/operator/${operatorId}`,
+      method: "DELETE",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Get Operator record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags operator
+   * @name OperatorDetail
+   * @summary Get Operator record
+   * @request GET:/operator/{operator_id}
+   */
+  operatorDetail = (operatorId: string, params: RequestParams = {}) =>
+    this.request<OperatorDetailData, void>({
+      path: `/operator/${operatorId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Edit Operator record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags operator
+   * @name OperatorPartialUpdate
+   * @summary Edit Operator record
+   * @request PATCH:/operator/{operator_id}
+   */
+  operatorPartialUpdate = (operatorId: string, data: OperatorPartialUpdatePayload, params: RequestParams = {}) =>
+    this.request<OperatorPartialUpdateData, void>({
+      path: `/operator/${operatorId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Query all Operator records <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags operator
+   * @name OperatorList
+   * @summary Query all Operator records
+   * @request GET:/operator
+   */
+  operatorList = (params: RequestParams = {}) =>
+    this.request<OperatorListData, void>({
+      path: `/operator`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description Add Operator record <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags operator
+   * @name OperatorCreate
+   * @summary Add Operator record
+   * @request POST:/operator
+   */
+  operatorCreate = (data: OperatorCreatePayload, params: RequestParams = {}) =>
+    this.request<OperatorCreateData, void>({
+      path: `/operator`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/operator/RestaurantCuisine.ts
+++ b/api/__generated__/operator/RestaurantCuisine.ts
@@ -1,0 +1,127 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  RestaurantCuisineCreateData,
+  RestaurantCuisineCreatePayload,
+  RestaurantCuisineDeleteData,
+  RestaurantCuisineDetailData,
+  RestaurantCuisineListData,
+  RestaurantCuisinePartialUpdateData,
+  RestaurantCuisinePartialUpdatePayload,
+  RestaurantCuisineUpdateData,
+  RestaurantCuisineUpdatePayload,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class RestaurantCuisine<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
+  /**
+   * @description <br /><br /> <b>Authentication:</b> required
+   *
+   * @tags restaurant_cuisine
+   * @name RestaurantCuisineDelete
+   * @request DELETE:/restaurant_cuisine/{restaurant_cuisine_id}
+   * @secure
+   */
+  restaurantCuisineDelete = (restaurantCuisineId: number, params: RequestParams = {}) =>
+    this.request<RestaurantCuisineDeleteData, void>({
+      path: `/restaurant_cuisine/${restaurantCuisineId}`,
+      method: "DELETE",
+      secure: true,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_cuisine
+   * @name RestaurantCuisineDetail
+   * @request GET:/restaurant_cuisine/{restaurant_cuisine_id}
+   */
+  restaurantCuisineDetail = (restaurantCuisineId: number, params: RequestParams = {}) =>
+    this.request<RestaurantCuisineDetailData, void>({
+      path: `/restaurant_cuisine/${restaurantCuisineId}`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_cuisine
+   * @name RestaurantCuisinePartialUpdate
+   * @request PATCH:/restaurant_cuisine/{restaurant_cuisine_id}
+   */
+  restaurantCuisinePartialUpdate = (
+    restaurantCuisineId: number,
+    data: RestaurantCuisinePartialUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<RestaurantCuisinePartialUpdateData, void>({
+      path: `/restaurant_cuisine/${restaurantCuisineId}`,
+      method: "PATCH",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_cuisine
+   * @name RestaurantCuisineUpdate
+   * @request PUT:/restaurant_cuisine/{restaurant_cuisine_id}
+   */
+  restaurantCuisineUpdate = (
+    restaurantCuisineId: number,
+    data: RestaurantCuisineUpdatePayload,
+    params: RequestParams = {},
+  ) =>
+    this.request<RestaurantCuisineUpdateData, void>({
+      path: `/restaurant_cuisine/${restaurantCuisineId}`,
+      method: "PUT",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_cuisine
+   * @name RestaurantCuisineList
+   * @request GET:/restaurant_cuisine
+   */
+  restaurantCuisineList = (params: RequestParams = {}) =>
+    this.request<RestaurantCuisineListData, void>({
+      path: `/restaurant_cuisine`,
+      method: "GET",
+      format: "json",
+      ...params,
+    });
+  /**
+   * @description <br /><br /> <b>Authentication:</b> not required
+   *
+   * @tags restaurant_cuisine
+   * @name RestaurantCuisineCreate
+   * @request POST:/restaurant_cuisine
+   */
+  restaurantCuisineCreate = (data: RestaurantCuisineCreatePayload, params: RequestParams = {}) =>
+    this.request<RestaurantCuisineCreateData, void>({
+      path: `/restaurant_cuisine`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+}

--- a/api/__generated__/operator/data-contracts.ts
+++ b/api/__generated__/operator/data-contracts.ts
@@ -1,0 +1,687 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+export type AlertDeleteData = object;
+
+export interface AlertDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  message?: string;
+  /** @format int64 */
+  job_id?: number;
+  messages?: string;
+  json?: object;
+  status?: "OK" | "NG";
+}
+
+export interface AlertPartialUpdatePayload {
+  message?: string;
+  /** @format int64 */
+  job_id?: number;
+  messages?: string;
+  json?: object;
+  status?: "OK" | "NG";
+}
+
+export interface AlertPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  message?: string;
+  /** @format int64 */
+  job_id?: number;
+  messages?: string;
+  json?: object;
+  status?: "OK" | "NG";
+}
+
+export type AlertListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  message?: string;
+  /** @format int64 */
+  job_id?: number;
+  messages?: string;
+  json?: object;
+  status?: "OK" | "NG";
+}[];
+
+export interface AlertCreatePayload {
+  message?: string;
+  /** @format int64 */
+  job_id?: number;
+  messages?: string;
+  json?: object;
+  status?: "OK" | "NG";
+}
+
+export interface AlertCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  message?: string;
+  /** @format int64 */
+  job_id?: number;
+  messages?: string;
+  json?: object;
+  status?: "OK" | "NG";
+}
+
+export interface LoginCreatePayload {
+  /** @format email */
+  email?: string;
+  password?: string;
+}
+
+export interface LoginCreateData {
+  authToken?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format email */
+    email?: string;
+    /** @format password */
+    password?: string;
+    name?: string;
+  };
+}
+
+export interface GetAuthData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format email */
+  email?: string;
+  name?: string;
+}
+
+export interface SignupCreatePayload {
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  name?: string;
+}
+
+export interface SignupCreateData {
+  authToken?: string;
+  user?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format email */
+    email?: string;
+    /** @format password */
+    password?: string;
+    name?: string;
+  };
+}
+
+export type ChefSkillDeleteData = object;
+
+export interface ChefSkillDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  skill?: string;
+}
+
+export interface ChefSkillPartialUpdatePayload {
+  skill?: string;
+}
+
+export interface ChefSkillPartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  skill?: string;
+}
+
+export interface ChefSkillUpdatePayload {
+  skill?: string;
+}
+
+export interface ChefSkillUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  skill?: string;
+}
+
+export type ChefSkillListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  skill?: string;
+}[];
+
+export interface ChefSkillCreatePayload {
+  skill?: string;
+}
+
+export interface ChefSkillCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  skill?: string;
+}
+
+export interface JobApprovePartialUpdatePayload {
+  job_id?: string;
+  reason?: string;
+}
+
+export interface JobApprovePartialUpdateData {
+  job?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+  };
+  adminlog?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format int64 */
+    target_id?: number;
+    target_type?: string;
+    action?: string;
+    reason?: string;
+    /** @format uuid */
+    operator_id?: string | null;
+  };
+}
+
+export interface JobBanPartialUpdatePayload {
+  job_id?: string;
+  reason?: string;
+}
+
+export interface JobBanPartialUpdateData {
+  job?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    title?: string;
+    description?: string;
+    /** @format date */
+    work_date?: string;
+    /** @format timestamptz */
+    start_time?: number;
+    /** @format timestamptz */
+    end_time?: number;
+    hourly_rate?: number;
+    required_skills?: string[];
+    status?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** @format int64 */
+    restaurant_id?: number;
+    image?: string;
+    task?: string;
+    skill?: string;
+    whattotake?: string;
+    note?: string;
+    point?: string;
+    transportation?: string;
+    /** @default "1" */
+    is_approved?: boolean;
+  };
+  adminlog?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format int64 */
+    target_id?: number;
+    target_type?: string;
+    action?: string;
+    reason?: string;
+    /** @format uuid */
+    operator_id?: string | null;
+  };
+}
+
+export interface RestaurantApprovePartialUpdatePayload {
+  restaurant_id?: string;
+  reason?: string;
+}
+
+export interface RestaurantApprovePartialUpdateData {
+  restaurant?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    cuisine_type?: string;
+    business_hours?: string;
+    contact_info?: string;
+    profile_image?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** Whether the restaurant is active. */
+    is_active?: boolean;
+    /** @format uuid */
+    companies_id?: string | null;
+    station?: string;
+    access?: string;
+    rating?: number;
+    /** @default "1" */
+    is_approved?: boolean;
+    cuisine_category?: number[] | null;
+  };
+  adminlog?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format int64 */
+    target_id?: number;
+    target_type?: string;
+    action?: string;
+    reason?: string;
+    /** @format uuid */
+    operator_id?: string | null;
+  };
+}
+
+export interface RestaurantBanPartialUpdatePayload {
+  restaurant_id?: string;
+  reason?: string;
+}
+
+export interface RestaurantBanPartialUpdateData {
+  restaurant?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    address?: string;
+    cuisine_type?: string;
+    business_hours?: string;
+    contact_info?: string;
+    profile_image?: string;
+    /** @format timestamptz */
+    updated_at?: number;
+    /** Whether the restaurant is active. */
+    is_active?: boolean;
+    /** @format uuid */
+    companies_id?: string | null;
+    station?: string;
+    access?: string;
+    rating?: number;
+    /** @default "1" */
+    is_approved?: boolean;
+    cuisine_category?: number[] | null;
+  };
+  adminlog?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format int64 */
+    target_id?: number;
+    target_type?: string;
+    action?: string;
+    reason?: string;
+    /** @format uuid */
+    operator_id?: string | null;
+  };
+}
+
+export interface UserApprovePartialUpdatePayload {
+  user_id?: string;
+}
+
+export interface UserApprovePartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  name?: string;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  user_type?: string;
+  status?: string;
+  /** @format date */
+  last_login_at?: string | null;
+  /** @format date */
+  updated_at?: string | null;
+  skills?: string[];
+  experience_level?: string;
+  bio?: string;
+  certifications?: string[];
+  /** @format date */
+  dateofbirth?: string | null;
+  profile_image?: string;
+  is_approved?: boolean;
+}
+
+export interface UserBanPartialUpdatePayload {
+  user_id?: string;
+  reason?: string;
+}
+
+export interface UserBanPartialUpdateData {
+  result1?: {
+    /** @format uuid */
+    id?: string;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    name?: string;
+    /** @format email */
+    email?: string;
+    /** @format password */
+    password?: string;
+    user_type?: string;
+    status?: string;
+    /** @format date */
+    last_login_at?: string | null;
+    /** @format date */
+    updated_at?: string | null;
+    skills?: string[];
+    experience_level?: string;
+    bio?: string;
+    certifications?: string[];
+    /** @format date */
+    dateofbirth?: string | null;
+    profile_image?: string;
+    is_approved?: boolean;
+  };
+  adminlog?: {
+    /** @format int64 */
+    id?: number;
+    /**
+     * @format timestamptz
+     * @default "now"
+     */
+    created_at?: number;
+    /** @format int64 */
+    target_id?: number;
+    target_type?: string;
+    action?: string;
+    reason?: string;
+    /** @format uuid */
+    operator_id?: string | null;
+  };
+}
+
+export type OperatorDeleteData = object;
+
+export interface OperatorDetailData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  name?: string;
+}
+
+export interface OperatorPartialUpdatePayload {
+  /** @format email */
+  email?: string;
+  name?: string;
+}
+
+export interface OperatorPartialUpdateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  name?: string;
+}
+
+export type OperatorListData = {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  name?: string;
+}[];
+
+export interface OperatorCreatePayload {
+  /** @format email */
+  email?: string;
+  name?: string;
+}
+
+export interface OperatorCreateData {
+  /** @format uuid */
+  id?: string;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** @format email */
+  email?: string;
+  /** @format password */
+  password?: string;
+  name?: string;
+}
+
+export type RestaurantCuisineDeleteData = object;
+
+export interface RestaurantCuisineDetailData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}
+
+export interface RestaurantCuisinePartialUpdatePayload {
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}
+
+export interface RestaurantCuisinePartialUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}
+
+export interface RestaurantCuisineUpdatePayload {
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}
+
+export interface RestaurantCuisineUpdateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}
+
+export type RestaurantCuisineListData = {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}[];
+
+export interface RestaurantCuisineCreatePayload {
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}
+
+export interface RestaurantCuisineCreateData {
+  /** @format int64 */
+  id?: number;
+  /**
+   * @format timestamptz
+   * @default "now"
+   */
+  created_at?: number;
+  /** Whether this cuisine is the primary cuisine for the restaurant. */
+  is_primary?: boolean;
+  category?: string;
+}

--- a/api/__generated__/operator/http-client.ts
+++ b/api/__generated__/operator/http-client.ts
@@ -1,0 +1,146 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  axiosInstance: AxiosInstance;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public instance: AxiosInstance;
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private secure?: boolean;
+  private format?: ResponseType;
+
+  constructor({ axiosInstance, securityWorker, secure, format, ...axiosConfig }: ApiConfig<SecurityDataType> = {}) {
+    this.instance = axiosInstance;
+    this.instance.defaults.baseURL = "https://xcti-onox-8bdw.n7e.xano.io/api:grw3Vlqa";
+    this.secure = secure;
+    this.format = format;
+    this.securityWorker = securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected mergeRequestParams(params1: AxiosRequestConfig, params2?: AxiosRequestConfig): AxiosRequestConfig {
+    const method = params1.method || (params2 && params2.method);
+
+    return {
+      ...this.instance.defaults,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...((method && this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) || {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected stringifyFormItem(formItem: unknown) {
+    if (typeof formItem === "object" && formItem !== null) {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
+  protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
+    return Object.keys(input || {}).reduce((formData, key) => {
+      const property = input[key];
+      const propertyContent: any[] = property instanceof Array ? property : [property];
+
+      for (const formItem of propertyContent) {
+        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        formData.append(key, isFileType ? formItem : this.stringifyFormItem(formItem));
+      }
+
+      return formData;
+    }, new FormData());
+  }
+
+  public request = async <T = any, _E = any>({
+    secure,
+    path,
+    type,
+    query,
+    format,
+    body,
+    ...params
+  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const responseFormat = format || this.format || undefined;
+
+    if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
+      body = this.createFormData(body as Record<string, unknown>);
+    }
+
+    if (type === ContentType.Text && body && body !== null && typeof body !== "string") {
+      body = JSON.stringify(body);
+    }
+
+    return this.instance.request({
+      ...requestParams,
+      headers: {
+        ...(requestParams.headers || {}),
+        ...(type ? { "Content-Type": type } : {}),
+      },
+      params: query,
+      responseType: responseFormat,
+      data: body,
+      url: path,
+    });
+  };
+}

--- a/api/api-factory.ts
+++ b/api/api-factory.ts
@@ -1,0 +1,23 @@
+import type { AxiosInstance } from 'axios';
+import axiosInstance from './axios';
+
+type Constructor<T> = new (args: { axiosInstance: AxiosInstance }) => T;
+
+// 自動で API クラスのマップを作る（PascalCase 前提）
+const apiCache = new Map<string, any>();
+
+/**
+* @description
+* この関数は、指定された API クラスのインスタンスを取得します。
+* もしインスタンスがまだ作成されていない場合は、新しいインスタンスを作成します。
+* @param ApiClass - インスタンス化する API クラス
+* @returns - 指定された API クラスのインスタンス
+*/
+export function getApi<T>(ApiClass: Constructor<T>): T {
+  const className = ApiClass.name;
+  if (!apiCache.has(className)) {
+    // axios のインスタンスを渡して API クラスを初期化
+    apiCache.set(className, new ApiClass({ axiosInstance: axiosInstance }));
+  }
+  return apiCache.get(className);
+}

--- a/api/axios.ts
+++ b/api/axios.ts
@@ -1,0 +1,59 @@
+/**
+* @fileoverview Axiosインスタンスの設定
+* @description APIリクエストのためのAxiosインスタンスを作成し、リクエストとレスポンスのインターセプターを設定します。
+*/
+
+import axios from 'axios';
+import { getAuthToken, clearAuthToken } from '@/lib/api/config';
+
+const instance = axios.create({
+  headers: {
+    Accept: 'application/json',
+  },
+});
+
+// リクエストインターセプター
+instance.interceptors.request.use((config) => {
+  const userType = config.headers['X-User-Type'] || 'chef'; // デフォルトは 'chef'
+  const token = getAuthToken(userType);
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  // JSONかFormDataかでContent-Typeを制御
+  const isFormData = config.data instanceof FormData;
+  if (!isFormData) {
+    config.headers['Content-Type'] = 'application/json';
+  }
+
+  console.log('API Request:', {
+    url: config.url,
+    method: config.method,
+    headers: config.headers,
+    data: isFormData ? 'FormData' : config.data,
+  });
+
+  return config;
+});
+
+// レスポンスインターセプター
+instance.interceptors.response.use(
+  (response) => {
+    console.log('API Success Response:', response.data);
+    return response;
+  },
+  async (error) => {
+    console.error('API Error Response:', error.response?.data);
+    // 認証エラー (401) の場合、ログアウト処理など
+    if (error.response?.status === 401) {
+      clearAuthToken();
+      // リダイレクトやエラー表示など
+      console.log('Authentication error, redirecting to login...');
+      // 認証エラー処理をここに追加（例：ログインページへリダイレクト）
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default instance;

--- a/lib/redux/slices/companyJobsSlice.ts
+++ b/lib/redux/slices/companyJobsSlice.ts
@@ -1,6 +1,7 @@
-import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
-import { getAllJobs, jobApi, Job } from "@/lib/api/job";
-import { getCurrentUser } from "@/lib/api/config";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { Job } from "@/lib/api/job";
+import { getApi } from "@/api/api-factory";
+import { Job as JobApi } from "@/api/__generated__/chef-connect/Job";
 
 interface CompanyJobsState {
   jobs: Job[];
@@ -18,7 +19,7 @@ export const fetchCompanyJobs = createAsyncThunk<any, void>(
   "companyJobs/fetch",
   async (_, { rejectWithValue }) => {
     try {
-      const response = (await jobApi.getJobs()).jobs;
+      const response = (await getApi(JobApi).getJob2()).data.jobs;
       console.log("API Response in company slice:", response);
       return response;
     } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,9 @@
         "eslint-config-next": "15.2.4",
         "jsdom": "^26.0.0",
         "postcss": "^8",
+        "swagger-typescript-api": "^13.0.28",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.19.3",
         "typescript": "^5",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.1.1"
@@ -77,7 +79,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1143,6 +1144,12 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+      "dev": true
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
@@ -1663,7 +1670,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -1678,7 +1684,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1688,7 +1693,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1698,14 +1702,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1873,7 +1875,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1887,7 +1888,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1897,7 +1897,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1921,7 +1920,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1932,7 +1930,7 @@
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
       "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.51.1"
@@ -3512,7 +3510,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3522,11 +3520,17 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/swagger-schema-official": {
+      "version": "2.0.25",
+      "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.25.tgz",
+      "integrity": "sha512-T92Xav+Gf/Ik1uPW581nA+JftmjWPgskw/WBf4TJzxRG/SJ+DfNnNE+WuZ4mrXuzflQMqMkm1LSYjzYW7MB1Cg==",
+      "dev": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4252,14 +4256,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4269,11 +4271,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4591,7 +4603,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4615,7 +4626,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4727,6 +4737,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4741,7 +4757,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4815,7 +4830,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4840,13 +4854,21 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "dev": true,
+      "dependencies": {
+        "consola": "^3.2.3"
       }
     },
     "node_modules/class-variance-authority": {
@@ -4866,6 +4888,69 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -4935,7 +5020,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4948,12 +5032,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4980,7 +5099,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5007,7 +5125,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5211,14 +5329,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -5286,6 +5402,30 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "node_modules/es-abstract": {
       "version": "1.23.9",
@@ -5463,6 +5603,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.25.2",
@@ -5954,6 +6100,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eta": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.2.0.tgz",
+      "integrity": "sha512-UVQ72Rqjy/ZKQalzV5dCCJP80GrmPrMxh6NlNf+erV6ObL0ZFkhCstWRawS85z3smdr3d2wXPsZEY7rDPfGd2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
@@ -6015,11 +6173,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6057,7 +6220,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6189,7 +6351,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6248,6 +6409,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6354,7 +6524,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6564,6 +6733,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http2-client": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+      "dev": true
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -6728,7 +6903,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -6794,7 +6968,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6845,7 +7018,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6899,7 +7071,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6925,7 +7096,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7150,7 +7320,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -7236,6 +7405,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7328,7 +7503,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7341,7 +7515,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -7446,7 +7619,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7456,7 +7628,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7464,6 +7635,17 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -7540,7 +7722,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -7665,6 +7846,69 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dev": true,
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+      "dev": true,
+      "dependencies": {
+        "es6-promise": "^3.2.1"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -7676,7 +7920,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7699,11 +7942,107 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-linter": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/schemasafe": "^1.0.0-rc.2",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-linter/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-resolver": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-schema-walker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+      "dev": true,
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.8",
+        "oas-linter": "^3.2.2",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "reftools": "^1.1.9",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7713,7 +8052,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7919,6 +8257,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
@@ -7955,7 +8311,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -8007,13 +8362,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -8023,7 +8377,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8033,7 +8386,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8043,7 +8395,7 @@
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
       "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.51.1"
@@ -8062,7 +8414,7 @@
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
       "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -8085,7 +8437,6 @@
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
       "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8114,7 +8465,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -8132,7 +8482,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -8152,7 +8501,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8188,7 +8536,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8214,7 +8561,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8228,7 +8574,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -8239,6 +8584,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -8317,7 +8677,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8493,7 +8852,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -8503,13 +8861,23 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -8564,6 +8932,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/reftools": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -8592,6 +8969,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -8602,7 +8988,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -8643,7 +9028,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -8720,7 +9104,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8953,6 +9336,60 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "dev": true,
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+      "dev": true
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -9363,7 +9800,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -9386,7 +9822,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -9396,7 +9831,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -9417,7 +9851,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -9433,14 +9866,12 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sucrase/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -9456,7 +9887,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -9486,13 +9916,99 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==",
+      "dev": true
+    },
+    "node_modules/swagger-typescript-api": {
+      "version": "13.0.28",
+      "resolved": "https://registry.npmjs.org/swagger-typescript-api/-/swagger-typescript-api-13.0.28.tgz",
+      "integrity": "sha512-8IwPD6nCFDTtzSl8rS7xlAx0NGMpBUlFfccJwgMV7t8d/nKw1yQWPVdC7h94XDsDPrLFvICd5xAJJm2TK2Pcpw==",
+      "dev": true,
+      "dependencies": {
+        "@types/swagger-schema-official": "^2.0.25",
+        "citty": "^0.1.6",
+        "consola": "^3.4.2",
+        "cosmiconfig": "^9.0.0",
+        "eta": "^2.2.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "nanoid": "^5.1.5",
+        "prettier": "~3.5.3",
+        "swagger-schema-official": "2.0.0-bab6bed",
+        "swagger2openapi": "^7.0.8",
+        "typescript": "~5.8.2"
+      },
+      "bin": {
+        "sta": "dist/cli.js",
+        "swagger-typescript-api": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/swagger-typescript-api/node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/swagger2openapi": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+      "dev": true,
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.8",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "oas-validator": "^5.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "boast": "boast.js",
+        "oas-validate": "oas-validate.js",
+        "swagger2openapi": "swagger2openapi.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/swagger2openapi/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/swr": {
@@ -9535,7 +10051,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -9582,7 +10097,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9599,7 +10113,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9612,7 +10125,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -9622,7 +10134,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -9660,19 +10171,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -9729,7 +10227,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -9790,7 +10287,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfck": {
@@ -9845,6 +10341,39 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
+      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10101,7 +10630,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -10612,6 +11140,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -10623,13 +11160,71 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
       "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "generate_apis": "tsx scripts/generate-apis/generate-apis.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.0",
@@ -61,7 +62,9 @@
     "eslint-config-next": "15.2.4",
     "jsdom": "^26.0.0",
     "postcss": "^8",
+    "swagger-typescript-api": "^13.0.28",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.19.3",
     "typescript": "^5",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.1"

--- a/scripts/generate-apis/generate-apis.ts
+++ b/scripts/generate-apis/generate-apis.ts
@@ -1,0 +1,63 @@
+import path from "path";
+import { generateApi } from "swagger-typescript-api";
+
+type ApiDefinition = {
+  outputDir: string;
+  url: string;
+};
+
+const aPIs: ApiDefinition[] = [
+  {
+    outputDir: "application",
+    url: "https://xcti-onox-8bdw.n7e.xano.io/apispec:MJ8mZ3fN?type=json&token=",
+  },
+  {
+    outputDir: "authentication",
+    url: "https://xcti-onox-8bdw.n7e.xano.io/apispec:xaJlLYDj?type=json&token=",
+  },
+  {
+    outputDir: "chef-connect",
+    url: "https://xcti-onox-8bdw.n7e.xano.io/apispec:Mv5jTolf?type=json&token=",
+  },
+  {
+    outputDir: "company",
+    url: "https://xcti-onox-8bdw.n7e.xano.io/apispec:3LZoUG6X?type=json&token=",
+  },
+  {
+    outputDir: "operator",
+    url: "https://xcti-onox-8bdw.n7e.xano.io/apispec:grw3Vlqa?type=json&token=",
+  },
+];
+
+const baseConfig = {
+  defaultResponseAsSuccess: false,
+  // リクエストボディ、リクエストパラメータ、レスポンスボディ、レスポンスエラーの型を生成する
+  extractRequestBody: true,
+  extractRequestParams: true,
+  extractResponseBody: true,
+  extractResponseError: true,
+  httpClientType: "axios" as const,
+  modular: true,
+  nameCase: 'camel',
+  templates: path.resolve(process.cwd(), "scripts/generate-apis/templates"),
+  unionEnums: true,
+};
+
+const generateApiTypes = async () => {
+  try {
+    await Promise.all(
+      aPIs.map(({ url, outputDir }) =>
+        generateApi({
+          ...baseConfig,
+          url,
+          output: path.resolve(process.cwd(), "api/__generated__", outputDir),
+        })
+      )
+    );
+    console.log("全てのAPI型定義ファイルを生成しました");
+  } catch (error) {
+    console.error("型生成エラー:", error);
+  }
+};
+
+generateApiTypes();

--- a/scripts/generate-apis/swagger-typescript-api.d.ts
+++ b/scripts/generate-apis/swagger-typescript-api.d.ts
@@ -1,0 +1,17 @@
+declare module 'swagger-typescript-api' {
+  export function generateApi(options: {
+    defaultResponseAsSuccess?: boolean;
+    extractRequestBody?: boolean;
+    extractRequestParams?: boolean;
+    extractResponseBody?: boolean;
+    extractResponseError?: boolean;
+    httpClientType?: string;
+    modular?: boolean;
+    name?: string;
+    nameCase?: string;
+    output: string;
+    templates?: string;
+    unionEnums?: boolean;
+    url: string;
+  }): Promise<void>;
+}

--- a/scripts/generate-apis/templates/api.ejs
+++ b/scripts/generate-apis/templates/api.ejs
@@ -1,0 +1,28 @@
+<%
+const { utils, route, config, modelTypes } = it;
+const { _, pascalCase, require } = utils;
+const apiClassName = pascalCase(route.moduleName);
+const routes = route.routes;
+const dataContracts = _.map(modelTypes, "name");
+%>
+
+<% if (config.httpClientType === config.constants.HTTP_CLIENT.AXIOS) { %> import type { AxiosRequestConfig, AxiosResponse } from "axios"; <% } %>
+
+import { HttpClient, RequestParams, ContentType, HttpResponse } from "./<%~ config.fileNames.httpClient %>";
+<% if (dataContracts.length) { %>
+import { <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %>"
+<% } %>
+
+export class <%= apiClassName %><SecurityDataType = unknown><% if (!config.singleHttpClient) { %> extends HttpClient<SecurityDataType> <% } %> {
+<% if(config.singleHttpClient) { %>
+  http: HttpClient<SecurityDataType>;
+
+  constructor (http: HttpClient<SecurityDataType>) {
+    this.http = http;
+  }
+<% } %>
+
+    <% for (const route of routes) { %>
+        <%~ includeFile('./procedure-call.ejs', { ...it, route }) %>
+    <% } %>
+}

--- a/scripts/generate-apis/templates/data-contract-jsdoc.ejs
+++ b/scripts/generate-apis/templates/data-contract-jsdoc.ejs
@@ -1,0 +1,37 @@
+<%
+const { data, utils } = it;
+const { formatDescription, require, _ } = utils;
+
+const stringify = (value) => _.isObject(value) ? JSON.stringify(value) : _.isString(value) ? `"${value}"` : value
+
+const jsDocLines = _.compact([
+    data.title,
+    data.description && formatDescription(data.description),
+    !_.isUndefined(data.deprecated) && data.deprecated && '@deprecated',
+    !_.isUndefined(data.format) && `@format ${data.format}`,
+    !_.isUndefined(data.minimum) && `@min ${data.minimum}`,
+    !_.isUndefined(data.multipleOf) && `@multipleOf ${data.multipleOf}`,
+    !_.isUndefined(data.exclusiveMinimum) && `@exclusiveMin ${data.exclusiveMinimum}`,
+    !_.isUndefined(data.maximum) && `@max ${data.maximum}`,
+    !_.isUndefined(data.minLength) && `@minLength ${data.minLength}`,
+    !_.isUndefined(data.maxLength) && `@maxLength ${data.maxLength}`,
+    !_.isUndefined(data.exclusiveMaximum) && `@exclusiveMax ${data.exclusiveMaximum}`,
+    !_.isUndefined(data.maxItems) && `@maxItems ${data.maxItems}`,
+    !_.isUndefined(data.minItems) && `@minItems ${data.minItems}`,
+    !_.isUndefined(data.uniqueItems) && `@uniqueItems ${data.uniqueItems}`,
+    !_.isUndefined(data.default) && `@default ${stringify(data.default)}`,
+    !_.isUndefined(data.pattern) && `@pattern ${data.pattern}`,
+    !_.isUndefined(data.example) && `@example ${stringify(data.example)}`
+]).join('\n').split('\n');
+%>
+<% if (jsDocLines.every(_.isEmpty)) { %>
+<% } else if (jsDocLines.length === 1) { %>
+/** <%~ jsDocLines[0] %> */
+<% } else if (jsDocLines.length) { %>
+/**
+<% for (jsDocLine of jsDocLines) { %>
+ * <%~ jsDocLine %>
+
+<% } %>
+ */
+<% } %>

--- a/scripts/generate-apis/templates/data-contracts.ejs
+++ b/scripts/generate-apis/templates/data-contracts.ejs
@@ -1,0 +1,40 @@
+<%
+const { modelTypes, utils, config } = it;
+const { formatDescription, require, _, Ts } = utils;
+
+
+const buildGenerics = (contract) => {
+  if (!contract.genericArgs || !contract.genericArgs.length) return '';
+
+  return '<' + contract.genericArgs.map(({ name, default: defaultType, extends: extendsType }) => {
+    return [
+      name,
+      extendsType && `extends ${extendsType}`,
+      defaultType && `= ${defaultType}`,
+    ].join('')
+  }).join(',') + '>'
+}
+
+const dataContractTemplates = {
+  enum: (contract) => {
+    return `enum ${contract.name} {\r\n${contract.content} \r\n }`;
+  },
+  interface: (contract) => {
+    return `interface ${contract.name}${buildGenerics(contract)} {\r\n${contract.content}}`;
+  },
+  type: (contract) => {
+    return `type ${contract.name}${buildGenerics(contract)} = ${contract.content}`;
+  },
+}
+%>
+
+<% if (config.internalTemplateOptions.addUtilRequiredKeysType) { %>
+type <%~ config.Ts.CodeGenKeyword.UtilRequiredKeys %><T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+<% } %>
+
+<% for (const contract of modelTypes) { %>
+  <%~ includeFile('./data-contract-jsdoc.ejs', { ...it, data: { ...contract, ...contract.typeData } }) %>
+  <%~ contract.internal ? '' : 'export'%> <%~ (dataContractTemplates[contract.typeIdentifier] || dataContractTemplates.type)(contract) %>
+
+
+<% } %>

--- a/scripts/generate-apis/templates/enum-data-contract.ejs
+++ b/scripts/generate-apis/templates/enum-data-contract.ejs
@@ -1,0 +1,12 @@
+<%
+const { contract, utils, config } = it;
+const { formatDescription, require, _ } = utils;
+const { name, $content } = contract;
+%>
+<% if (config.generateUnionEnums) { %>
+  export type <%~ name %> = <%~ _.map($content, ({ value }) => value).join(" | ") %>
+<% } else { %>
+  export enum <%~ name %> {
+    <%~ _.map($content, ({ key, value }) => `${key} = ${value}`).join(",\n") %>
+  }
+<% } %>

--- a/scripts/generate-apis/templates/http-client.ejs
+++ b/scripts/generate-apis/templates/http-client.ejs
@@ -1,0 +1,143 @@
+<%
+const { apiConfig, generateResponses, config } = it;
+%>
+
+import type { AxiosInstance, AxiosRequestConfig, HeadersDefaults, ResponseType, AxiosResponse } from "axios";
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+
+export interface ApiConfig<SecurityDataType = unknown> extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  axiosInstance: AxiosInstance;
+  securityWorker?: (securityData: SecurityDataType | null) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = "application/json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+    public instance: AxiosInstance;
+    private securityData: SecurityDataType | null = null;
+    private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+    private secure?: boolean;
+    private format?: ResponseType;
+
+    constructor({ axiosInstance, securityWorker, secure, format, ...axiosConfig }: ApiConfig<SecurityDataType> = {}) {
+        this.instance = axiosInstance;
+        this.instance.defaults.baseURL = "<%~ apiConfig.baseUrl %>";
+        this.secure = secure;
+        this.format = format;
+        this.securityWorker = securityWorker;
+    }
+
+    public setSecurityData = (data: SecurityDataType | null) => {
+        this.securityData = data
+    }
+
+    protected mergeRequestParams(params1: AxiosRequestConfig, params2?: AxiosRequestConfig): AxiosRequestConfig {
+      const method = params1.method || (params2 && params2.method)
+
+      return {
+        ...this.instance.defaults,
+        ...params1,
+        ...(params2 || {}),
+        headers: {
+          ...((method && this.instance.defaults.headers[method.toLowerCase() as keyof HeadersDefaults]) || {}),
+          ...(params1.headers || {}),
+          ...((params2 && params2.headers) || {}),
+        },
+      };
+    }
+
+    protected stringifyFormItem(formItem: unknown) {
+      if (typeof formItem === "object" && formItem !== null) {
+        return JSON.stringify(formItem);
+      } else {
+        return `${formItem}`;
+      }
+    }
+
+    protected createFormData(input: Record<string, unknown>): FormData {
+      if (input instanceof FormData) {
+        return input;
+      }
+      return Object.keys(input || {}).reduce((formData, key) => {
+        const property = input[key];
+        const propertyContent: any[] = (property instanceof Array) ? property : [property]
+
+        for (const formItem of propertyContent) {
+          const isFileType = formItem instanceof Blob || formItem instanceof File;
+          formData.append(
+            key,
+            isFileType ? formItem : this.stringifyFormItem(formItem)
+            );
+        }
+
+        return formData;
+      }, new FormData());
+    }
+
+    public request = async <T = any, _E = any>({
+        secure,
+        path,
+        type,
+        query,
+        format,
+        body,
+        ...params
+<% if (config.unwrapResponseData) { %>
+    }: FullRequestParams): Promise<T> => {
+<% } else { %>
+    }: FullRequestParams): Promise<AxiosResponse<T>> => {
+<% } %>
+        const secureParams = ((typeof secure === 'boolean' ? secure : this.secure) && this.securityWorker && (await this.securityWorker(this.securityData))) || {};
+        const requestParams = this.mergeRequestParams(params, secureParams);
+        const responseFormat = (format || this.format) || undefined;
+
+        if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
+          body = this.createFormData(body as Record<string, unknown>);
+        }
+
+        if (type === ContentType.Text && body && body !== null && typeof body !== "string") {
+          body = JSON.stringify(body);
+        }
+
+        return this.instance.request({
+            ...requestParams,
+            headers: {
+                ...(requestParams.headers || {}),
+                ...(type ? { "Content-Type": type } : {}),
+            },
+            params: query,
+            responseType: responseFormat,
+            data: body,
+            url: path,
+<% if (config.unwrapResponseData) { %>
+        }).then(response => response.data);
+<% } else { %>
+        });
+<% } %>
+    };
+}

--- a/scripts/generate-apis/templates/interface-data-contract.ejs
+++ b/scripts/generate-apis/templates/interface-data-contract.ejs
@@ -1,0 +1,10 @@
+<%
+const { contract, utils } = it;
+const { formatDescription, require, _ } = utils;
+%>
+export interface <%~ contract.name %> {
+  <% for (const field of contract.$content) { %>
+    <%~ includeFile('./object-field-jsdoc.ejs', { ...it, field }) %>
+    <%~ field.name %><%~ field.isRequired ? '' : '?' %>: <%~ field.value %><%~ field.isNullable ? ' | null' : ''%>;
+  <% } %>
+}

--- a/scripts/generate-apis/templates/object-field-jsdoc.ejs
+++ b/scripts/generate-apis/templates/object-field-jsdoc.ejs
@@ -1,0 +1,28 @@
+<%
+const { field, utils } = it;
+const { formatDescription, require, _ } = utils;
+
+const comments = _.uniq(
+    _.compact([
+        field.title,
+        field.description,
+        field.deprecated && ` * @deprecated`,
+        !_.isUndefined(field.format) && `@format ${field.format}`,
+        !_.isUndefined(field.minimum) && `@min ${field.minimum}`,
+        !_.isUndefined(field.maximum) && `@max ${field.maximum}`,
+        !_.isUndefined(field.pattern) && `@pattern ${field.pattern}`,
+        !_.isUndefined(field.example) &&
+        `@example ${_.isObject(field.example) ? JSON.stringify(field.example) : field.example}`,
+    ]).reduce((acc, comment) => [...acc, ...comment.split(/\n/g)], []),
+);
+%>
+<% if (comments.length === 1) { %>
+  /** <%~ comments[0] %> */
+<% } else if (comments.length) { %>
+  /**
+  <% comments.forEach(comment => { %>
+   * <%~ comment %>
+
+  <% }) %>
+   */
+<% } %>

--- a/scripts/generate-apis/templates/procedure-call.ejs
+++ b/scripts/generate-apis/templates/procedure-call.ejs
@@ -1,0 +1,100 @@
+<%
+const { utils, route, config } = it;
+const { requestBodyInfo, responseBodyInfo, specificArgNameResolver } = route;
+const { _, getInlineParseContent, getParseContent, parseSchema, getComponentByRef, require } = utils;
+const { parameters, path, method, payload, query, formData, security, requestParams } = route.request;
+const { type, errorType, contentTypes } = route.response;
+const { HTTP_CLIENT, RESERVED_REQ_PARAMS_ARG_NAMES } = config.constants;
+const routeDocs = includeFile("@base/route-docs", { config, route, utils });
+const queryName = (query && query.name) || "query";
+const pathParams = _.values(parameters);
+const pathParamsNames = _.map(pathParams, "name");
+
+const isFetchTemplate = config.httpClientType === HTTP_CLIENT.FETCH;
+
+const requestConfigParam = {
+    name: specificArgNameResolver.resolve(RESERVED_REQ_PARAMS_ARG_NAMES),
+    optional: true,
+    type: "RequestParams",
+    defaultValue: "{}",
+}
+
+const argToTmpl = ({ name, optional, type, defaultValue }) => `${name}${!defaultValue && optional ? '?' : ''}: ${type}${defaultValue ? ` = ${defaultValue}` : ''}`;
+
+const rawWrapperArgs = config.extractRequestParams ?
+    _.compact([
+        requestParams && {
+          name: pathParams.length ? `{ ${_.join(pathParamsNames, ", ")}, ...${queryName} }` : queryName,
+          optional: false,
+          type: getInlineParseContent(requestParams),
+        },
+        ...(!requestParams ? pathParams : []),
+        payload,
+        requestConfigParam,
+    ]) :
+    _.compact([
+        ...pathParams,
+        query,
+        payload,
+        requestConfigParam,
+    ])
+
+const wrapperArgs = _
+    // Sort by optionality
+    .sortBy(rawWrapperArgs, [o => o.optional])
+    .map(argToTmpl)
+    .join(', ')
+
+// RequestParams["type"]
+const requestContentKind = {
+    "JSON": "ContentType.Json",
+    "URL_ENCODED": "ContentType.UrlEncoded",
+    "FORM_DATA": "ContentType.FormData",
+    "TEXT": "ContentType.Text",
+}
+// RequestParams["format"]
+const responseContentKind = {
+    "JSON": '"json"',
+    "IMAGE": '"blob"',
+    "FORM_DATA": isFetchTemplate ? '"formData"' : '"document"'
+}
+
+const bodyTmpl = _.get(payload, "name") || null;
+const queryTmpl = (query != null && queryName) || null;
+const bodyContentKindTmpl = requestContentKind[requestBodyInfo.contentKind] || null;
+const responseFormatTmpl = responseContentKind[responseBodyInfo.success && responseBodyInfo.success.schema && responseBodyInfo.success.schema.contentKind] || null;
+const securityTmpl = security ? 'true' : null;
+
+const describeReturnType = () => {
+    if (!config.toJS) return "";
+
+    switch(config.httpClientType) {
+        case HTTP_CLIENT.AXIOS: {
+          return `Promise<AxiosResponse<${type}>>`
+        }
+        default: {
+          return `Promise<HttpResponse<${type}, ${errorType}>`
+        }
+    }
+}
+
+%>
+/**
+<%~ routeDocs.description %>
+
+ *<% /* Here you can add some other JSDoc tags */ %>
+
+<%~ routeDocs.lines %>
+
+ */
+<%~ route.routeName.usage %> = (<%~ wrapperArgs %>)<%~ config.toJS ? `: ${describeReturnType()}` : "" %> =>
+    <%~ config.singleHttpClient ? 'this.http.request' : 'this.request' %><<%~ type %>, <%~ errorType %>>({
+        path: `<%~ path %>`,
+        method: '<%~ _.upperCase(method) %>',
+        <%~ queryTmpl ? `query: ${queryTmpl},` : '' %>
+        <%~ bodyTmpl ? `body: ${bodyTmpl},` : '' %>
+        <%~ securityTmpl ? `secure: ${securityTmpl},` : '' %>
+        <%~ bodyContentKindTmpl ? `type: ${bodyContentKindTmpl},` : '' %>
+        <%~ responseFormatTmpl ? `format: ${responseFormatTmpl},` : '' %>
+        ...<%~ _.get(requestConfigParam, "name") %>,
+    })

--- a/scripts/generate-apis/templates/route-docs.ejs
+++ b/scripts/generate-apis/templates/route-docs.ejs
@@ -1,0 +1,30 @@
+<%
+const { config, route, utils } = it;
+const { _, formatDescription, fmtToJSDocLine, pascalCase, require } = utils;
+const { raw, request, routeName } = route;
+
+const jsDocDescription = raw.description ?
+    ` * @description ${formatDescription(raw.description, true)}` :
+    fmtToJSDocLine('No description', { eol: false });
+const jsDocLines = _.compact([
+    _.size(raw.tags) && ` * @tags ${raw.tags.join(", ")}`,
+    ` * @name ${pascalCase(routeName.usage)}`,
+    raw.summary && ` * @summary ${raw.summary}`,
+    ` * @request ${_.upperCase(request.method)}:${raw.route}`,
+    raw.deprecated && ` * @deprecated`,
+    routeName.duplicate && ` * @originalName ${routeName.original}`,
+    routeName.duplicate && ` * @duplicate`,
+    request.security && ` * @secure`,
+    ...(config.generateResponses && raw.responsesTypes.length
+    ? raw.responsesTypes.map(
+        ({ type, status, description, isSuccess }) =>
+            ` * @response \`${status}\` \`${_.replace(_.replace(type, /\/\*/g, "\\*"), /\*\//g, "*\\")}\` ${description}`,
+        )
+    : []),
+]).map(str => str.trimEnd()).join("\n");
+
+return {
+  description: jsDocDescription,
+  lines: jsDocLines,
+}
+%>

--- a/scripts/generate-apis/templates/route-name.ejs
+++ b/scripts/generate-apis/templates/route-name.ejs
@@ -1,0 +1,43 @@
+<%
+const { routeInfo, utils } = it;
+const {
+  operationId,
+  method,
+  route,
+  moduleName,
+  responsesTypes,
+  description,
+  tags,
+  summary,
+  pathArgs,
+} = routeInfo;
+const { _, fmtToJSDocLine, require } = utils;
+
+const methodAliases = {
+  get: (pathName, hasPathInserts) =>
+    _.camelCase(`${pathName}_${hasPathInserts ? "detail" : "list"}`),
+  post: (pathName, hasPathInserts) => _.camelCase(`${pathName}_create`),
+  put: (pathName, hasPathInserts) => _.camelCase(`${pathName}_update`),
+  patch: (pathName, hasPathInserts) => _.camelCase(`${pathName}_partial_update`),
+  delete: (pathName, hasPathInserts) => _.camelCase(`${pathName}_delete`),
+};
+
+const createCustomOperationId = (method, route, moduleName) => {
+  const hasPathInserts = /\{(\w){1,}\}$/g.test(route);
+  const splittedRouteBySlash = _.compact(_.replace(route, /\{(\w){1,}\}/g, "").split("/"));
+  const routeParts = (splittedRouteBySlash.length > 1
+    ? splittedRouteBySlash.splice(1)
+    : splittedRouteBySlash
+  ).join("_");
+  return routeParts.length > 3 && methodAliases[method]
+    ? methodAliases[method](routeParts, hasPathInserts)
+    : _.camelCase(_.lowerCase(method) + "_" + [moduleName].join("_")) || "index";
+};
+
+if (operationId)
+  return _.camelCase(operationId);
+if (route === "/")
+  return _.camelCase(`${_.lowerCase(method)}Root`);
+
+return createCustomOperationId(method, route, moduleName);
+%>

--- a/scripts/generate-apis/templates/route-type.ejs
+++ b/scripts/generate-apis/templates/route-type.ejs
@@ -1,0 +1,23 @@
+<%
+const { route, utils, config } = it;
+const { _, pascalCase, require } = utils;
+const { query, payload, pathParams, headers } = route.request;
+
+const routeDocs = includeFile("./route-docs", { config, route, utils });
+const routeNamespace = pascalCase(route.routeName.usage);
+
+%>
+
+/**
+<%~ routeDocs.description %>
+
+<%~ routeDocs.lines %>
+
+*/
+export namespace <%~ routeNamespace %> {
+  export type RequestParams = <%~ (pathParams && pathParams.type) || '{}' %>;
+  export type RequestQuery = <%~ (query && query.type) || '{}' %>;
+  export type RequestBody = <%~ (payload && payload.type) || 'never' %>;
+  export type RequestHeaders = <%~ (headers && headers.type) || '{}' %>;
+  export type ResponseBody = <%~ route.response.type %>;
+}

--- a/scripts/generate-apis/templates/route-types.ejs
+++ b/scripts/generate-apis/templates/route-types.ejs
@@ -1,0 +1,18 @@
+<%
+const { utils, config, route, modelTypes } = it;
+const { _, pascalCase } = utils;
+const { routes, moduleName } = route;
+const dataContracts = config.modular ? _.map(modelTypes, "name") : [];
+
+%>
+<% if (dataContracts.length) { %>
+import { <%~ dataContracts.join(", ") %> } from "./<%~ config.fileNames.dataContracts %>"
+<% } %>
+
+export namespace <%~ pascalCase(moduleName) %> {
+    <% for (const route of routes) { %>
+
+        <%~ includeFile('@base/route-type.ejs', { ...it, route }) %>
+
+    <% } %>
+}

--- a/scripts/generate-apis/templates/type-data-contract.ejs
+++ b/scripts/generate-apis/templates/type-data-contract.ejs
@@ -1,0 +1,15 @@
+<%
+const { contract, utils } = it;
+const { formatDescription, require, _ } = utils;
+
+%>
+<% if (contract.$content.length) { %>
+export type <%~ contract.name %> = {
+  <% for (const field of contract.$content) { %>
+    <%~ includeFile('./object-field-jsdoc.ejs', { ...it, field }) %>
+    <%~ field.field %>;
+  <% } %>
+}<%~ utils.isNeedToAddNull(contract) ? ' | null' : ''%>
+<% } else { %>
+export type <%~ contract.name %> = Record<string, any>;
+<% } %>


### PR DESCRIPTION
- swagger-typescript-api を使ってSwaggerからAPIクライアントを自動生成
    - `npm run generate_apis` で自動生成されます
    - axiosを使用
        - lib/api/config.ts に定義されていたインターセプトの内容などは、api/axios.ts に定義
- 型は api/__generated__/application(Swaggerのページごとに存在するフォルダ)/data-contracts.ts の中に定義されています
- APIの呼び出し方
    - `getApi()`の引数に使いたいAPIのクラスを指定して、インスタンス化
    - 生成されたインスタンスから使いたいAPIの関数を呼び出す
    - axiosを使っているので、`.data`でデータが取り出せる

```
const response = (await getApi(JobApi).getJob2()).data.jobs;
```

- lib/redux/slices/companyJobsSlice.ts にお試しで実装してみました。問題なさそう