### PR TITLE
Araki fix

### DIFF
--- a/api/__generated__/base/data-contracts.ts
+++ b/api/__generated__/base/data-contracts.ts
@@ -6339,13 +6339,11 @@ export interface RestaurantsDetailData {
 export interface RestaurantsPartialUpdatePayload {
   name: string;
   address: string;
-  cuisine_type: string;
   business_hours: string;
   contact_info: string;
   profile_image: string;
   station: string;
   access: string;
-  rating: number;
   restaurant_cuisine_id: number[];
   description: string;
   phone: string;
@@ -6400,28 +6398,15 @@ export type RestaurantsListOutput = {
 export interface RestaurantsCreatePayload {
   name: string;
   address: string;
-  cuisine_type: string;
   business_hours: string;
   contact_info: string;
-  profile_image: string;
-  /** @format timestamptz */
-  updated_at: number;
-  /**
-   * Whether the restaurant is active.
-   * @default "false"
-   */
-  is_active: boolean;
   /** @format uuid */
   companies_id: string | null;
   station: string;
   access: string;
-  rating: number;
-  /** @default "1" */
-  is_approved: boolean;
   restaurant_cuisine_id: number[];
   description: string;
   phone: string;
-  status: "BANNED" | "PENDING" | "DELETED" | "APPROVED";
   /** @format binary */
   photo: File | null;
 }

--- a/api/__generated__/base/data-contracts.ts
+++ b/api/__generated__/base/data-contracts.ts
@@ -1803,8 +1803,8 @@ export interface CompaniesDetailData {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -1818,12 +1818,6 @@ export interface CompaniesPartialUpdatePayload {
   phone: string;
   website: string;
   description: string;
-  status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
-  business_registration_number: string;
-  logo_url: string;
-  stripe_customer_id: string;
   /** @format email */
   company_email: string;
 }
@@ -1842,8 +1836,8 @@ export interface CompaniesPartialUpdateData {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -1937,8 +1931,8 @@ export interface JobsListData {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;
@@ -2048,8 +2042,8 @@ export type CompaniesListData = {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -2064,8 +2058,8 @@ export interface CompaniesCreatePayload {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -2091,8 +2085,8 @@ export interface CompaniesCreateData {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;
@@ -3121,8 +3115,8 @@ export interface CompanyDetailResult {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;
@@ -5061,8 +5055,8 @@ export interface CompanyusersDetailData {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;
@@ -6068,8 +6062,8 @@ export interface CompanyusersListOutput {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;

--- a/api/__generated__/base/data-contracts.ts
+++ b/api/__generated__/base/data-contracts.ts
@@ -3061,19 +3061,11 @@ export type JobChangeRequestsListData = {
 
 export interface JobChangeRequestsCreatePayload {
   /** @format int64 */
-  job_id: number;
-  /** @format uuid */
-  user_id: string | null;
-  /** @format int64 */
   requested_by: number;
   proposed_changes: object;
-  status: "PENDING" | "APPROVED" | "REJECTED";
-  /** @format timestamptz */
-  updated_at: number | null;
   reason: string;
   /** @format int64 */
   worksession_id: number;
-  as_is: object;
 }
 
 export interface JobChangeRequestsCreateData {

--- a/api/__generated__/company/data-contracts.ts
+++ b/api/__generated__/company/data-contracts.ts
@@ -351,14 +351,6 @@ export interface InitialCreatePayload {
   phone: string;
   website: string;
   description: string;
-  status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
-  business_registration_number: string;
-  logo_url: string;
-  stripe_customer_id: string;
-  /** @format email */
-  company_email: string;
   companyUser_id: string;
   /** @format binary */
   photo: File | null;
@@ -379,8 +371,8 @@ export interface InitialCreateData {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;
@@ -704,8 +696,8 @@ export interface CompaniesDetailData {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -720,8 +712,8 @@ export interface CompaniesPartialUpdatePayload {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -743,8 +735,8 @@ export interface CompaniesPartialUpdateData {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -851,8 +843,8 @@ export type CompaniesListData = {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -867,8 +859,8 @@ export interface CompaniesCreatePayload {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -890,8 +882,8 @@ export interface CompaniesCreateData {
   website: string;
   description: string;
   status: "pending" | "approved" | "banned" | "rejected";
-  /** @format date */
-  updated_at: string | null;
+  /** @format timestamptz */
+  updated_at: number | null;
   business_registration_number: string;
   logo_url: string;
   stripe_customer_id: string;
@@ -960,8 +952,8 @@ export interface SignupCreateResult {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;
@@ -1321,8 +1313,8 @@ export interface CompanyusersDetailData {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;

--- a/api/__generated__/notification/CompanyuserNotification.ts
+++ b/api/__generated__/notification/CompanyuserNotification.ts
@@ -11,9 +11,9 @@
  */
 
 import {
-  ByUserDetailResult1,
-  MarkReadAllPartialUpdateInput1,
-  MarkReadAllPartialUpdateOutput1,
+  ByUserDetailOutput1,
+  MarkReadAllPartialUpdateBody1,
+  MarkReadAllPartialUpdateData1,
   MarkReadPartialUpdateResult,
 } from "./data-contracts";
 import { ContentType, HttpClient, RequestParams } from "./http-client";
@@ -30,7 +30,7 @@ export class CompanyuserNotification<
    * @request GET:/companyuser_notification/byUser/{user_id}
    */
   byUserDetail = (userId: string, params: RequestParams = {}) =>
-    this.request<ByUserDetailResult1, void>({
+    this.request<ByUserDetailOutput1, void>({
       path: `/companyuser_notification/byUser/${userId}`,
       method: "GET",
       format: "json",
@@ -57,10 +57,10 @@ export class CompanyuserNotification<
    * @request PATCH:/companyuser_notification/mark-read/all
    */
   markReadAllPartialUpdate = (
-    data: MarkReadAllPartialUpdateInput1,
+    data: MarkReadAllPartialUpdateBody1,
     params: RequestParams = {},
   ) =>
-    this.request<MarkReadAllPartialUpdateOutput1, void>({
+    this.request<MarkReadAllPartialUpdateData1, void>({
       path: `/companyuser_notification/mark-read/all`,
       method: "PATCH",
       body: data,
@@ -76,8 +76,8 @@ export class CompanyuserNotification<
     const key = enabled ? [`/companyuser_notification/mark-read/all`] : null;
     const fetcher: (
       url: string[],
-      { arg }: { arg: MarkReadAllPartialUpdateInput1 },
-    ) => Promise<MarkReadAllPartialUpdateOutput1> = (_, { arg }) =>
+      { arg }: { arg: MarkReadAllPartialUpdateBody1 },
+    ) => Promise<MarkReadAllPartialUpdateData1> = (_, { arg }) =>
       this.markReadAllPartialUpdate(arg, params).then((res) => res.data);
     return [key, fetcher] as const;
   };

--- a/api/__generated__/notification/CompanyuserNotification.ts
+++ b/api/__generated__/notification/CompanyuserNotification.ts
@@ -11,9 +11,9 @@
  */
 
 import {
-  ByUserDetailData1,
-  MarkReadAllPartialUpdateData1,
-  MarkReadAllPartialUpdateInput1,
+  ByUserDetailResult1,
+  MarkReadAllPartialUpdateBody1,
+  MarkReadAllPartialUpdateResult1,
   MarkReadPartialUpdateResult,
 } from "./data-contracts";
 import { ContentType, HttpClient, RequestParams } from "./http-client";
@@ -30,7 +30,7 @@ export class CompanyuserNotification<
    * @request GET:/companyuser_notification/byUser/{user_id}
    */
   byUserDetail = (userId: string, params: RequestParams = {}) =>
-    this.request<ByUserDetailData1, void>({
+    this.request<ByUserDetailResult1, void>({
       path: `/companyuser_notification/byUser/${userId}`,
       method: "GET",
       format: "json",
@@ -57,10 +57,10 @@ export class CompanyuserNotification<
    * @request PATCH:/companyuser_notification/mark-read/all
    */
   markReadAllPartialUpdate = (
-    data: MarkReadAllPartialUpdateInput1,
+    data: MarkReadAllPartialUpdateBody1,
     params: RequestParams = {},
   ) =>
-    this.request<MarkReadAllPartialUpdateData1, void>({
+    this.request<MarkReadAllPartialUpdateResult1, void>({
       path: `/companyuser_notification/mark-read/all`,
       method: "PATCH",
       body: data,
@@ -76,8 +76,8 @@ export class CompanyuserNotification<
     const key = enabled ? [`/companyuser_notification/mark-read/all`] : null;
     const fetcher: (
       url: string[],
-      { arg }: { arg: MarkReadAllPartialUpdateInput1 },
-    ) => Promise<MarkReadAllPartialUpdateData1> = (_, { arg }) =>
+      { arg }: { arg: MarkReadAllPartialUpdateBody1 },
+    ) => Promise<MarkReadAllPartialUpdateResult1> = (_, { arg }) =>
       this.markReadAllPartialUpdate(arg, params).then((res) => res.data);
     return [key, fetcher] as const;
   };

--- a/api/__generated__/notification/CompanyuserNotification.ts
+++ b/api/__generated__/notification/CompanyuserNotification.ts
@@ -12,8 +12,8 @@
 
 import {
   ByUserDetailResult1,
-  MarkReadAllPartialUpdateBody1,
-  MarkReadAllPartialUpdateResult1,
+  MarkReadAllPartialUpdateInput1,
+  MarkReadAllPartialUpdateOutput1,
   MarkReadPartialUpdateResult,
 } from "./data-contracts";
 import { ContentType, HttpClient, RequestParams } from "./http-client";
@@ -57,10 +57,10 @@ export class CompanyuserNotification<
    * @request PATCH:/companyuser_notification/mark-read/all
    */
   markReadAllPartialUpdate = (
-    data: MarkReadAllPartialUpdateBody1,
+    data: MarkReadAllPartialUpdateInput1,
     params: RequestParams = {},
   ) =>
-    this.request<MarkReadAllPartialUpdateResult1, void>({
+    this.request<MarkReadAllPartialUpdateOutput1, void>({
       path: `/companyuser_notification/mark-read/all`,
       method: "PATCH",
       body: data,
@@ -76,8 +76,8 @@ export class CompanyuserNotification<
     const key = enabled ? [`/companyuser_notification/mark-read/all`] : null;
     const fetcher: (
       url: string[],
-      { arg }: { arg: MarkReadAllPartialUpdateBody1 },
-    ) => Promise<MarkReadAllPartialUpdateResult1> = (_, { arg }) =>
+      { arg }: { arg: MarkReadAllPartialUpdateInput1 },
+    ) => Promise<MarkReadAllPartialUpdateOutput1> = (_, { arg }) =>
       this.markReadAllPartialUpdate(arg, params).then((res) => res.data);
     return [key, fetcher] as const;
   };

--- a/api/__generated__/notification/data-contracts.ts
+++ b/api/__generated__/notification/data-contracts.ts
@@ -259,7 +259,7 @@ export interface MarkReadPartialUpdateData {
   restaurant_id: number | null;
 }
 
-export type ByUserDetailResult1 = {
+export type ByUserDetailOutput1 = {
   /** @format uuid */
   id: string;
   /**
@@ -286,11 +286,11 @@ export type ByUserDetailResult1 = {
   restaurant_id: number | null;
 }[];
 
-export interface MarkReadAllPartialUpdateInput1 {
+export interface MarkReadAllPartialUpdateBody1 {
   user_id: string;
 }
 
-export type MarkReadAllPartialUpdateOutput1 = {
+export type MarkReadAllPartialUpdateData1 = {
   /** @format uuid */
   id: string;
   /**

--- a/api/__generated__/notification/data-contracts.ts
+++ b/api/__generated__/notification/data-contracts.ts
@@ -259,7 +259,7 @@ export interface MarkReadPartialUpdateData {
   restaurant_id: number | null;
 }
 
-export type ByUserDetailData1 = {
+export type ByUserDetailResult1 = {
   /** @format uuid */
   id: string;
   /**
@@ -286,11 +286,11 @@ export type ByUserDetailData1 = {
   restaurant_id: number | null;
 }[];
 
-export interface MarkReadAllPartialUpdateInput1 {
+export interface MarkReadAllPartialUpdateBody1 {
   user_id: string;
 }
 
-export type MarkReadAllPartialUpdateData1 = {
+export type MarkReadAllPartialUpdateResult1 = {
   /** @format uuid */
   id: string;
   /**

--- a/api/__generated__/notification/data-contracts.ts
+++ b/api/__generated__/notification/data-contracts.ts
@@ -286,11 +286,11 @@ export type ByUserDetailResult1 = {
   restaurant_id: number | null;
 }[];
 
-export interface MarkReadAllPartialUpdateBody1 {
+export interface MarkReadAllPartialUpdateInput1 {
   user_id: string;
 }
 
-export type MarkReadAllPartialUpdateResult1 = {
+export type MarkReadAllPartialUpdateOutput1 = {
   /** @format uuid */
   id: string;
   /**

--- a/api/__generated__/operator/data-contracts.ts
+++ b/api/__generated__/operator/data-contracts.ts
@@ -435,8 +435,8 @@ export type BillingsAllListData = {
     website: string;
     description: string;
     status: "pending" | "approved" | "banned" | "rejected";
-    /** @format date */
-    updated_at: string | null;
+    /** @format timestamptz */
+    updated_at: number | null;
     business_registration_number: string;
     logo_url: string;
     stripe_customer_id: string;

--- a/app/admin/job/[id]/page.tsx
+++ b/app/admin/job/[id]/page.tsx
@@ -39,7 +39,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useGetJob } from "@/hooks/api/companyuser/jobs/useGetJob";
+import { useGetJob } from "@/hooks/api/all/jobs/useGetJob";
 import { useGetWorksessionsByJobId } from "@/hooks/api/companyuser/worksessions/useGetWorksessionsByJobId";
 import {
   JobsDetailData,

--- a/app/admin/stores/[id]/components/JobContent.tsx
+++ b/app/admin/stores/[id]/components/JobContent.tsx
@@ -195,7 +195,11 @@ export function JobContent({
             <Calendar className="h-4 w-4" />
           </Button>
         </div>
-        <Button size="sm" onClick={() => setIsCreateJobModalOpen(true)}>
+        <Button
+          size="sm"
+          onClick={() => setIsCreateJobModalOpen(true)}
+          disabled={restaurant?.status !== "APPROVED"}
+        >
           <Plus className="h-4 w-4 mr-2" />
           求人を追加
         </Button>

--- a/app/admin/stores/[id]/components/RestaurantDetail.tsx
+++ b/app/admin/stores/[id]/components/RestaurantDetail.tsx
@@ -12,6 +12,8 @@ import { useGetRestaurant } from "@/hooks/api/companyuser/restaurants/useGetRest
 import { useCompanyAuth } from "@/lib/contexts/CompanyAuthContext";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { ErrorPage } from "@/components/layout/ErrorPage";
+import { Badge } from "@/components/ui/badge";
+import { useGetRestaurantCuisines } from "@/hooks/api/all/restaurantCuisines/useGetRestaurantCuisines";
 
 interface RestaurantDetailProps {
   restaurantId: number;
@@ -22,6 +24,8 @@ export function RestaurantDetail({
 }: RestaurantDetailProps) {
   const { user } = useCompanyAuth();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
+  const { data: cuisines, error: errorGetCuisines, isLoading: isCuisinesLoading } = useGetRestaurantCuisines();
 
   // レストラン情報の取得
   const {
@@ -64,9 +68,9 @@ export function RestaurantDetail({
           <CardTitle>店舗詳細</CardTitle>
         </CardHeader>
         <CardContent>
-          {restaurantError ? (
+          {restaurantError || errorGetCuisines ? (
             <ErrorPage />
-          ) : isRestaurantLoading ? (
+          ) : isRestaurantLoading || isCuisinesLoading ? (
             <div className="flex justify-center items-center min-h-[200px]">
               <LoadingSpinner />
             </div>
@@ -87,9 +91,15 @@ export function RestaurantDetail({
 
               <div>
                 <h4 className="font-medium">ジャンル</h4>
-                <p className="text-sm text-gray-500">
-                  {restaurant?.cuisine_type}
-                </p>
+                {restaurant != null && restaurant.restaurant_cuisine_id.length > 0 && (
+                  <div className="flex flex-wrap gap-2 mt-1">
+                    {cuisines?.filter((cuisine) => restaurant.restaurant_cuisine_id.includes(cuisine.id)).map((cuisine) => (
+                      <Badge key={cuisine.id} variant="secondary">
+                        {cuisine.category}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
               </div>
               <div>
                 <h4 className="font-medium">説明文</h4>
@@ -129,28 +139,14 @@ export function RestaurantDetail({
           )}
         </CardContent>
       </Card>
-      <EditRestaurantModal
-        isOpen={isEditModalOpen && !!restaurant}
-        onClose={() => setIsEditModalOpen(false)}
-        onSubmit={handleSubmit}
-        restaurant={
-          restaurant || {
-            id: 0,
-            name: "",
-            description: "",
-            address: "",
-            contact_info: "",
-            cuisine_type: "",
-            is_active: true,
-            is_approved: false,
-            profile_image: "",
-            restaurant_cuisine_id: [],
-            business_hours: "",
-            station: "",
-            access: "",
-          }
-        }
-      />
+      {restaurant &&
+        <EditRestaurantModal
+          isOpen={isEditModalOpen && !!restaurant}
+          onClose={() => setIsEditModalOpen(false)}
+          onSubmit={handleSubmit}
+          restaurant={restaurant}
+        />
+      }
     </>
   )
 };

--- a/app/admin/stores/[id]/page.tsx
+++ b/app/admin/stores/[id]/page.tsx
@@ -17,6 +17,8 @@ import { StaffList } from "./components/StaffList";
 import { JobContent } from "./components/JobContent";
 import { ErrorPage } from "@/components/layout/ErrorPage";
 import { LoadingScreen } from "@/components/LoadingScreen";
+import { RestaurantStatusBadgeForAdmin } from "@/components/badge/RestaurantStatusBadgeForAdmin";
+import { useGetRestaurantCuisines } from "@/hooks/api/all/restaurantCuisines/useGetRestaurantCuisines";
 
 interface EditStaffPermissions {
   canEdit: boolean;
@@ -54,6 +56,8 @@ export default function RestaurantDetailPage(props: {
     restaurantId: Number(params.id),
   });
 
+  const { data: cuisines, error: errorGetCuisines, isLoading: isCuisinesLoading } = useGetRestaurantCuisines();
+
   // const handleEditStaff = async () => {
   //   if (!editTargetStaff) return;
 
@@ -79,11 +83,11 @@ export default function RestaurantDetailPage(props: {
   //   }
   // };
 
-  if (restaurantError || reviewError) {
+  if (restaurantError || reviewError || errorGetCuisines) {
     return <ErrorPage />;
   }
 
-  if (restaurantLoading || reviewLoading) {
+  if (restaurantLoading || reviewLoading || !restaurant || isCuisinesLoading) {
     return (
       <LoadingScreen
         fullScreen={false}
@@ -92,9 +96,17 @@ export default function RestaurantDetailPage(props: {
     );
   }
 
+  if (restaurant?.status === "DELETED") {
+    return (
+      <ErrorPage
+        errorMessage="この店舗は削除されているため、詳細を表示できません。"
+      />
+    );
+  }
+
   return (
     <div className="relative h-full">
-      {restaurant?.is_approved === false && (
+      {restaurant?.status === "BANNED" && (
         <div className="absolute inset-0 backdrop-blur-sm z-50 flex items-center justify-center pointer-events-auto">
           <div className="text-center p-6 bg-white/90 rounded-xl shadow-md border">
             <h2 className="text-xl font-semibold text-gray-800 mb-2">店舗へのアクセスが制限されています</h2>
@@ -138,15 +150,17 @@ export default function RestaurantDetailPage(props: {
               </div> */}
               <div className="flex-1">
                 <div className="flex items-center gap-2 mb-1">
-                  <Badge className="bg-green-500 hover:bg-green-600">
-                    {restaurant?.is_active ? "公開中" : "非公開"}
-                  </Badge>
-                  {restaurant?.cuisine_type && (
-                    <Badge
-                      variant="outline"
-                      className="bg-white/20 backdrop-blur-sm text-white border-white/40">
-                      {restaurant?.cuisine_type}
-                    </Badge>
+                  <RestaurantStatusBadgeForAdmin
+                    status={restaurant.status}
+                  />
+                  {restaurant.restaurant_cuisine_id.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {cuisines?.filter((cuisine) => restaurant.restaurant_cuisine_id.includes(cuisine.id)).map((cuisine) => (
+                        <Badge key={cuisine.id} variant="secondary">
+                          {cuisine.category}
+                        </Badge>
+                      ))}
+                    </div>
                   )}
                   {restaurantReview && restaurantReview.length > 0 && (
                     <Badge

--- a/app/chef/job/[id]/page.tsx
+++ b/app/chef/job/[id]/page.tsx
@@ -157,6 +157,7 @@ export default function JobDetail({ params }: PageProps) {
 
   const { trigger: cancelWorksessionTrigger } = useCancelWorksessionByChef({
     worksessionId: workSession?.id,
+    userId: user?.id,
   });
 
   // メッセージの取得
@@ -197,6 +198,7 @@ export default function JobDetail({ params }: PageProps) {
 
   const { trigger: acceptJobChangeRequest } = useAcceptJobChangeRequest({
     jobChangeRequestId: selectedChangeRequest?.id,
+    userId: user?.id,
   });
 
   const { trigger: rejectJobChangeRequest } = useRejectJobChangeRequest({

--- a/app/chef/job/[id]/page.tsx
+++ b/app/chef/job/[id]/page.tsx
@@ -32,7 +32,7 @@ import { useSubscriptionMessagesByUserId } from "@/hooks/api/user/messages/useSu
 import { useAuth } from "@/lib/contexts/AuthContext";
 import { useStartWorksession } from "@/hooks/api/user/worksessions/useStartWorksession";
 import { useFinishWorksession } from "@/hooks/api/user/worksessions/useFinishWorksession";
-import { useGetJob } from "@/hooks/api/companyuser/jobs/useGetJob";
+import { useGetJob } from "@/hooks/api/all/jobs/useGetJob";
 import { useCancelWorksessionByChef } from "@/hooks/api/user/worksessions/useCancelWorksessionByChef";
 import { useGetWorksessionsByUserId } from "@/hooks/api/user/worksessions/useGetWorksessionsByUserId";
 import { useSubscriptionUnreadMessagesByUser } from "@/hooks/api/user/messages/useSubscriptionUnreadMessagesByUser";

--- a/app/job/[id]/client.tsx
+++ b/app/job/[id]/client.tsx
@@ -17,7 +17,6 @@ import { useEffect, useState } from "react";
 import { getUserProfile } from "@/lib/api/user";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useMobile } from "@/hooks/use-mobile";
 import { ApplyJobModal } from "@/components/modals/ApplyJobModal";
 import { useAuth } from "@/lib/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
@@ -38,8 +37,6 @@ import {
 import { formatJapanHHMM } from "@/lib/functions";
 import { useApplyJob } from "@/hooks/api/user/jobs/useApplyJob";
 import { LoadingScreen } from "@/components/LoadingScreen";
-import { getApi } from "@/api/api-factory";
-import { Jobs } from "@/api/__generated__/base/Jobs";
 import { useSWRConfig } from "swr";
 
 // 時間のフォーマット関数を追加

--- a/app/operator/restaurants/page.tsx
+++ b/app/operator/restaurants/page.tsx
@@ -98,7 +98,7 @@ export default function RestaurantsPage() {
       searchQuery === "" ||
       restaurant.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       restaurant.email.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesStatus = !showSuspendedOnly || !restaurant.is_approved;
+    const matchesStatus = !showSuspendedOnly || restaurant.status !== "APPROVED";
     return matchesSearch && matchesStatus;
   });
 
@@ -165,10 +165,16 @@ export default function RestaurantsPage() {
                 <TableCell>{restaurant.email}</TableCell>
                 <TableCell>{restaurant.address || "-"}</TableCell>
                 <TableCell>
-                  {restaurant.is_approved ? (
+                  {restaurant.status === "APPROVED" ? (
                     <Badge variant="default">承認済み</Badge>
-                  ) : (
+                  ) : restaurant.status === "BANNED" ? (
                     <Badge variant="destructive">一時停止中</Badge>
+                  ) : restaurant.status === "PENDING" ? (
+                    <Badge variant="secondary">承認待ち</Badge>
+                  ) : restaurant.status === "DELETED" ? (
+                    <Badge variant="outline">削除済み</Badge>
+                  ) : (
+                    <Badge variant="outline">不明</Badge>
                   )}
                 </TableCell>
                 <TableCell>
@@ -205,13 +211,19 @@ export default function RestaurantsPage() {
                             <p>住所: {restaurant.address || "-"}</p>
                             <p>
                               ステータス:{" "}
-                              {restaurant.is_approved
+                              {restaurant.status === "APPROVED"
                                 ? "承認済み"
-                                : "一時停止中"}
+                                : restaurant.status === "BANNED"
+                                ? "一時停止中"
+                                : restaurant.status === "PENDING"
+                                ? "承認待ち"
+                                : restaurant.status === "DELETED"
+                                ? "削除済み"
+                                : "不明"}
                             </p>
                           </div>
                         </div>
-                        {!restaurant.is_approved ? (
+                        {restaurant.status === "BANNED" || restaurant.status === "PENDING" ? (
                           <div>
                             <h3 className="font-semibold mb-2">承認</h3>
                             <Button
@@ -221,7 +233,7 @@ export default function RestaurantsPage() {
                               承認する
                             </Button>
                           </div>
-                        ) : (
+                        ) : restaurant.status === "APPROVED" ? (
                           <div>
                             <h3 className="font-semibold mb-2">BAN</h3>
                             <Input
@@ -236,7 +248,7 @@ export default function RestaurantsPage() {
                               BANする
                             </Button>
                           </div>
-                        )}
+                        ): null}
                       </div>
                     </DialogContent>
                   </Dialog>

--- a/app/register/company-profile/page.tsx
+++ b/app/register/company-profile/page.tsx
@@ -15,37 +15,32 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Upload, Building2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCompanyAuth } from "@/lib/contexts/CompanyAuthContext";
-import { initializeCompany } from "@/lib/api/company";
 import { getAuthToken } from "@/lib/api/config";
 import { toast } from "@/hooks/use-toast";
 import { useForm } from "react-hook-form";
-
-type CompanyFormData = {
-  name: string;
-  description: string;
-  address: string;
-  phone: string;
-  website?: string;
-  business_registration_number?: string;
-};
+import { useCreateCompany } from "@/hooks/api/companyuser/companies/useCreateCompany";
+import { InitialCreatePayload } from "@/api/__generated__/company/data-contracts";
 
 export default function CompanyProfilePage() {
   const router = useRouter();
   const { user, reloadUser, isLoading } = useCompanyAuth();
-  const [profileImage, setProfileImage] = useState<string | null>(null);
+  // const [profileImage, setProfileImage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [checking, setChecking] = useState(true);
+
+  const {
+    trigger: initializeCompanyTrigger,
+  } = useCreateCompany({});
 
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<CompanyFormData>();
+  } = useForm<InitialCreatePayload>();
 
-  const onSubmit = async (data: CompanyFormData) => {
+  const onSubmit = async (data: InitialCreatePayload) => {
     if (!user?.id) {
       toast({
         title: "エラーが発生しました",
@@ -58,18 +53,10 @@ export default function CompanyProfilePage() {
     setIsSubmitting(true);
 
     try {
-      const companyData = {
+      await initializeCompanyTrigger({
         ...data,
-        logo_url: profileImage || "",
-        created_by: user.id,
-        status: "approved",
-      };
-
-      const initializedCompany = await initializeCompany(
-        user.id,
-        profileImage || "",
-        companyData
-      );
+        companyUser_id: user.id,
+      })
 
       const token = getAuthToken("company");
       if (!token) throw new Error("認証トークンが見つかりません");
@@ -94,16 +81,16 @@ export default function CompanyProfilePage() {
     }
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = () => {
-        setProfileImage(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-    }
-  };
+  // const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   const file = e.target.files?.[0];
+  //   if (file) {
+  //     const reader = new FileReader();
+  //     reader.onload = () => {
+  //       setProfileImage(reader.result as string);
+  //     };
+  //     reader.readAsDataURL(file);
+  //   }
+  // };
 
   useEffect(() => {
     // ユーザー情報ロード中は何もしない
@@ -239,7 +226,7 @@ export default function CompanyProfilePage() {
               </div>
 
               {/* 会社ロゴ */}
-              <div className="space-y-3">
+              {/* <div className="space-y-3">
                 <Label className="text-base">会社ロゴ（任意）</Label>
                 <div className="flex items-center gap-4">
                   <div className="relative w-24 h-24 border rounded-lg overflow-hidden flex items-center justify-center bg-gray-50">
@@ -273,7 +260,7 @@ export default function CompanyProfilePage() {
                     </p>
                   </div>
                 </div>
-              </div>
+              </div> */}
 
               <div className="flex justify-between pt-4">
                 <Button variant="outline" type="button" asChild>

--- a/components/badge/RestaurantStatusBadgeForAdmin.tsx
+++ b/components/badge/RestaurantStatusBadgeForAdmin.tsx
@@ -1,0 +1,27 @@
+import { RESTAURANT_STATUS } from "@/lib/const/restaurant";
+import { Badge } from "@/components/ui/badge";
+
+interface RestaurantStatusBadgeForAdminProps {
+  status: typeof RESTAURANT_STATUS[number]['value'];
+}
+
+export function RestaurantStatusBadgeForAdmin({
+  status,
+}: RestaurantStatusBadgeForAdminProps) {
+  return (
+    <Badge variant="secondary"
+      className={`${
+        status === "APPROVED"
+          ? "bg-green-100 text-green-800"
+          : status === "PENDING"
+            ? "bg-yellow-100 text-yellow-800"
+            : status === "BANNED"
+              ? "bg-red-100 text-red-800"
+              : status === "DELETED"
+                ? "bg-gray-100 text-gray-800"
+                : "bg-gray-200 text-gray-800"
+      }`}>
+      {RESTAURANT_STATUS.find(s => s.value === status)?.label || "不明"}
+    </Badge>
+  );
+};

--- a/components/chat/ChatSheet.tsx
+++ b/components/chat/ChatSheet.tsx
@@ -105,6 +105,7 @@ export function ChatSheet({
 
   const { trigger: acceptJobChangeRequest } = useAcceptJobChangeRequest({
     jobChangeRequestId: selectedChangeRequest?.id,
+    userId: user?.id,
   });
 
   const { trigger: rejectJobChangeRequest } = useRejectJobChangeRequest({

--- a/components/dropdownMenu/AdminJobActionsMenu.tsx
+++ b/components/dropdownMenu/AdminJobActionsMenu.tsx
@@ -102,13 +102,13 @@ export function AdminJobActionsMenu({
             onClick={() => {
               handleCancelClick();
             }}
-            className="text-red-600 focus:text-red-600 focus:bg-red-50">
+            className="text-red-600 focus:text-red-600 focus:bg-red-50 cursor-pointer">
             <XCircle className="h-4 w-4 mr-2" />
             キャンセル
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={handleOpenChangeRequestModal}
-            className="text-black-600 focus:text-black-600 focus:bg-black-50">
+            className="cursor-pointer">
             <Pencil className="h-4 w-4 mr-2" />
             シェフに業務内容の変更を依頼する
           </DropdownMenuItem>
@@ -117,7 +117,7 @@ export function AdminJobActionsMenu({
               onClick={() => {
                 handleNoShowClick();
               }}
-              className="text-red-600 focus:text-red-600 focus:bg-red-50">
+              className="text-red-600 focus:text-red-600 focus:bg-red-50 cursor-pointer">
               <XCircle className="h-4 w-4 mr-2" />
               ノーショー報告
             </DropdownMenuItem>

--- a/components/modals/CompanyProfileEditModal.tsx
+++ b/components/modals/CompanyProfileEditModal.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
-import { useForm, ControllerRenderProps, FieldValues } from "react-hook-form";
+"use client";
+
+import { useForm, ControllerRenderProps } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
-import { Building, Upload, X } from "lucide-react";
-import Image, { StaticImageData } from "next/image";
+import { Building } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -29,7 +29,6 @@ import {
   CompaniesPartialUpdatePayload,
   CompaniesDetailData,
 } from "@/api/__generated__/base/data-contracts";
-import useSWRMutation from "swr/mutation";
 
 const formSchema = z.object({
   name: z.string().min(1, "会社名は必須です"),
@@ -42,7 +41,7 @@ const formSchema = z.object({
     .optional()
     .or(z.literal("")),
   description: z.string().optional(),
-  logo: z.string().optional(),
+  // logo: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -58,7 +57,7 @@ export function CompanyProfileEditModal({
   onClose,
   company,
 }: CompanyProfileEditModalProps) {
-  const [isUploading, setIsUploading] = useState(false);
+  // const [isUploading, setIsUploading] = useState(false);
   const { trigger, isMutating} = useUpdateCompany({
     companyId: company.id,
   });
@@ -72,44 +71,44 @@ export function CompanyProfileEditModal({
       email: company.company_email,
       website: company.website || "",
       description: company.description || "",
-      logo: company.logo_url || "",
+      // logo: company.logo_url || "",
     },
   });
 
-  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  // const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   const file = e.target.files?.[0];
+  //   if (!file) return;
 
-    try {
-      setIsUploading(true);
-      const formData = new FormData();
-      formData.append("file", file);
+  //   try {
+  //     setIsUploading(true);
+  //     const formData = new FormData();
+  //     formData.append("file", file);
 
-      const response = await fetch("/api/upload", {
-        method: "POST",
-        body: formData,
-      });
+  //     const response = await fetch("/api/upload", {
+  //       method: "POST",
+  //       body: formData,
+  //     });
 
-      if (!response.ok) {
-        throw new Error("画像のアップロードに失敗しました");
-      }
+  //     if (!response.ok) {
+  //       throw new Error("画像のアップロードに失敗しました");
+  //     }
 
-      const data = await response.json();
-      form.setValue("logo", data.url);
-      toast({
-        title: "画像をアップロードしました",
-        description: "ロゴ画像が更新されました",
-      });
-    } catch (error) {
-      toast({
-        title: "エラー",
-        description: "画像のアップロードに失敗しました",
-        variant: "destructive",
-      });
-    } finally {
-      setIsUploading(false);
-    }
-  };
+  //     const data = await response.json();
+  //     form.setValue("logo", data.url);
+  //     toast({
+  //       title: "画像をアップロードしました",
+  //       description: "ロゴ画像が更新されました",
+  //     });
+  //   } catch (error) {
+  //     toast({
+  //       title: "エラー",
+  //       description: "画像のアップロードに失敗しました",
+  //       variant: "destructive",
+  //     });
+  //   } finally {
+  //     setIsUploading(false);
+  //   }
+  // };
 
   const onSubmit = async (data: FormValues) => {
     try {
@@ -119,11 +118,6 @@ export function CompanyProfileEditModal({
         phone: data.phone,
         website: data.website || "",
         description: data.description || "",
-        status: "approved",
-        updated_at: new Date().toISOString(),
-        business_registration_number: "",
-        logo_url: data.logo || "",
-        stripe_customer_id: "",
         company_email: data.email,
       };
 
@@ -158,8 +152,8 @@ export function CompanyProfileEditModal({
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
             <div className="space-y-4">
-              <div className="flex items-center gap-4">
-                {/* <div className="relative w-24 h-24 rounded-lg overflow-hidden bg-gray-100">
+              {/* <div className="flex items-center gap-4">
+                <div className="relative w-24 h-24 rounded-lg overflow-hidden bg-gray-100">
                   {form.watch("logo") ? (
                     <>
                       <Image
@@ -180,8 +174,8 @@ export function CompanyProfileEditModal({
                       <Building className="h-8 w-8" />
                     </div>
                   )}
-                </div> */}
-                {/* <div className="flex-1">
+                </div>
+                <div className="flex-1">
                   <FormField
                     control={form.control}
                     name="logo"
@@ -223,8 +217,8 @@ export function CompanyProfileEditModal({
                       </FormItem>
                     )}
                   />
-                </div> */}
-              </div>
+                </div>
+              </div> */}
 
               <FormField
                 control={form.control}
@@ -295,7 +289,6 @@ export function CompanyProfileEditModal({
                         <Input
                           placeholder="info@example.com"
                           {...field}
-                          disabled
                         />
                       </FormControl>
                       <FormMessage />

--- a/components/modals/CreateRestaurantModal.tsx
+++ b/components/modals/CreateRestaurantModal.tsx
@@ -1,6 +1,6 @@
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment, useState, useRef, useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -10,6 +10,7 @@ import { toast } from "@/hooks/use-toast";
 import Image from "next/image";
 import { RestaurantsCreatePayload } from "@/api/__generated__/base/data-contracts";
 import { useGetRestaurantCuisines } from "@/hooks/api/all/restaurantCuisines/useGetRestaurantCuisines";
+import { Checkbox } from "@/components/ui/checkbox";
 
 interface CreateRestaurantModalProps {
   isOpen: boolean;
@@ -27,7 +28,6 @@ export const CreateRestaurantModal = ({
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [selectedCuisines, setSelectedCuisines] = useState<number[]>([]);
 
   const { data: cuisines, error: errorGetCuisines } = useGetRestaurantCuisines();
 
@@ -42,31 +42,23 @@ export const CreateRestaurantModal = ({
     }
   }, [errorGetCuisines]);
 
-  const handleCuisineChange = (id: number) => {
-    setSelectedCuisines((prev) => {
-      if (prev.includes(id)) {
-        return prev.filter((item) => item !== id);
-      } else {
-        return [...prev, id];
-      }
-    });
-  };
-
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
     reset,
+    control,
   } = useForm<RestaurantsCreatePayload>({
     defaultValues: {
       companies_id: companyId.toString(),
-      is_active: false,
       name: "",
       address: "",
-      cuisine_type: "",
       business_hours: "",
+      contact_info: "",
       station: "",
       access: "",
+      restaurant_cuisine_id: [],
+      description: "",
     },
   });
 
@@ -90,25 +82,26 @@ export const CreateRestaurantModal = ({
     }
   };
 
+  const handleClose = () => {
+    removeImage();
+    reset();
+    onClose();
+  }
+
   const onSubmitHandler = handleSubmit(async (data) => {
     try {
       const newData: RestaurantsCreatePayload = {
         ...data,
-        restaurant_cuisine_id: selectedCuisines,
         photo: selectedFile,
       }
 
       await onSubmit(newData);
 
-      reset();
-      setPreviewImage(null);
-      setSelectedFile(null);
-      setSelectedCuisines([]);
-      onClose();
       toast({
         title: "店舗を追加しました",
         description: "新しい店舗の登録が完了しました。",
       });
+      handleClose();
     } catch (error) {
       console.error("Error submitting form:", error);
       toast({
@@ -121,7 +114,7 @@ export const CreateRestaurantModal = ({
 
   return (
     <Transition appear show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50" onClose={onClose}>
+      <Dialog as="div" className="relative z-50" onClose={handleClose}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"
@@ -187,23 +180,51 @@ export const CreateRestaurantModal = ({
                       <Label>ジャンル *</Label>
                       <div className="flex flex-wrap gap-2 mt-2">
                         {cuisines?.map((cuisine) => (
-                          <Button
+                          <div
                             key={cuisine.id}
-                            type="button"
-                            variant={
-                              selectedCuisines.includes(cuisine.id)
-                                ? "default"
-                                : "outline"
-                            }
-                            onClick={() => handleCuisineChange(cuisine.id)}
-                            className="rounded-full">
-                            {cuisine.category}
-                          </Button>
+                            className="flex items-center gap-2 px-3 py-1.5 bg-gray-50 rounded-full border border-gray-200">
+                            <Controller
+                              name="restaurant_cuisine_id"
+                              control={control}
+                              rules={{
+                                validate: (value) => {
+                                  if (!value || value.length === 0) {
+                                    return "ジャンルを１つ以上選択してください";
+                                  }
+                                  return true;
+                                },
+                              }}
+                              render={({ field }) => {
+                                const isChecked = field.value?.includes(cuisine.id);
+
+                                return (
+                                  <>
+                                    <Checkbox
+                                      id={`genre-${cuisine.id}`}
+                                      checked={isChecked}
+                                      onCheckedChange={(checked) => {
+                                        const newValue = checked
+                                          ? [...(field.value ?? []), cuisine.id]
+                                          : field.value?.filter((v: number) => v !== cuisine.id);
+                                        field.onChange(newValue);
+                                      }}
+                                      className="border-gray-300 data-[state=checked]:bg-[#DB3F1C] data-[state=checked]:border-[#DB3F1C]"
+                                    />
+                                    <Label
+                                      htmlFor={`genre-${cuisine.id}`}
+                                      className="text-sm text-gray-700">
+                                      {cuisine.category}
+                                    </Label>
+                                  </>
+                                )
+                              }}
+                            />
+                          </div>
                         ))}
                       </div>
-                      {selectedCuisines.length === 0 && (
+                      {errors.restaurant_cuisine_id && (
                         <p className="mt-1 text-sm text-red-600">
-                          少なくとも1つのジャンルを選択してください
+                          {errors.restaurant_cuisine_id.message}
                         </p>
                       )}
                     </div>
@@ -311,7 +332,7 @@ export const CreateRestaurantModal = ({
                     <Button
                       type="button"
                       variant="outline"
-                      onClick={onClose}
+                      onClick={handleClose}
                       disabled={isSubmitting}>
                       キャンセル
                     </Button>

--- a/components/modals/RestaurantReviewModal.tsx
+++ b/components/modals/RestaurantReviewModal.tsx
@@ -87,6 +87,7 @@ export function RestaurantReviewModal({
 
   const { trigger: rejectWorksessionTrigger } = useRejectWorksession({
     worksessionId: worksessionData?.id,
+    jobId: worksessionData?.job.id,
     handleSuccess: () => {
       toast({
         title: "差し戻しを送信しました",

--- a/hooks/api/all/jobs/useGetJob.ts
+++ b/hooks/api/all/jobs/useGetJob.ts
@@ -11,11 +11,7 @@ export const useGetJob = (params: Params) => {
   return useSWR(
     ...jobs.jobsDetailQueryArgs(
       params.jobId ?? -1,
-      {
-        headers: {
-          "X-User-Type": "company",
-        },
-      },
+      {},
       params.jobId != null
     )
   );

--- a/hooks/api/companyuser/companies/useCreateCompany.ts
+++ b/hooks/api/companyuser/companies/useCreateCompany.ts
@@ -1,0 +1,30 @@
+import { Companies } from '@/api/__generated__/company/Companies';
+import { getApi } from '@/api/api-factory';
+import useSWRMutation from 'swr/mutation'
+
+export interface Params {
+  handleSuccess?: (data: any) => void;
+  handleError?: (error: any) => void;
+}
+
+export const useCreateCompany = (params: Params) => {
+  const companiesApi = getApi(Companies);
+  return useSWRMutation(...companiesApi.initialCreateQueryArgs({
+    headers: {
+      "X-User-Type": "company"
+    }
+  }), {
+    onSuccess: (data) => {
+      // 成功時のコールバック
+      if (params.handleSuccess) {
+        params.handleSuccess(data);
+      }
+    },
+    onError: (error) => {
+      // エラー時のコールバック
+      if (params.handleError) {
+        params.handleError(error);
+      }
+    },
+  })
+}

--- a/hooks/api/companyuser/dashboard/userGetDashboardList.ts
+++ b/hooks/api/companyuser/dashboard/userGetDashboardList.ts
@@ -18,6 +18,9 @@ export const useGetDashboardList = (params: Params) => {
         },
       },
       params.companyuserId != null
-    )
+    ), {
+      revalidateOnMount: true,
+      dedupingInterval: 0,
+    }
   );
 };

--- a/hooks/api/companyuser/jobChangeRequests/useCreateJobChangeRequest.ts
+++ b/hooks/api/companyuser/jobChangeRequests/useCreateJobChangeRequest.ts
@@ -3,7 +3,12 @@ import { JobChangeRequests } from "@/api/__generated__/base/JobChangeRequests";
 import { getApi } from "@/api/api-factory";
 import { useSWRConfig } from "swr";
 
-export const useCreateJobChangeRequest = () => {
+interface Params {
+  handleSuccess?: () => void;
+  handleError?: (error: any) => void;
+}
+
+export const useCreateJobChangeRequest = (params: Params) => {
   const { mutate } = useSWRConfig();
 
   const jobChangeRequests = getApi(JobChangeRequests);
@@ -15,13 +20,22 @@ export const useCreateJobChangeRequest = () => {
     }),
     {
       onSuccess: (data) => {
-        console.log("Job change request created successfully:", data);
-
         // Job変更リクエストのリストのキャッシュを更新
         const jobChangeRequestsKey =
           jobChangeRequests.jobChangeRequestsListQueryArgs()[0];
         mutate(jobChangeRequestsKey);
+
+        // 成功時のコールバック
+        if (params.handleSuccess) {
+          params.handleSuccess();
+        }
       },
+      onError: (error) => {
+        // エラー時のコールバック
+        if (params.handleError) {
+          params.handleError(error);
+        }
+      }
     }
   );
 };

--- a/hooks/api/companyuser/worksessions/useRejectWorksession.ts
+++ b/hooks/api/companyuser/worksessions/useRejectWorksession.ts
@@ -8,7 +8,7 @@ import useSWRMutation from "swr/mutation";
 
 export interface Params {
   worksessionId?: number;
-  reason?: string;
+  jobId?: number;
   handleSuccess?: () => void;
   handleError?: () => void;
 }
@@ -29,6 +29,16 @@ export const useRejectWorksession = (params: Params) => {
     ),
     {
       onSuccess: () => {
+        // キャッシュを更新
+        if (params.jobId) {
+          const jobs = getApi(Jobs);
+          const worksessionsByJobIdKey =
+            jobs.worksessionsRestaurantTodosListQueryArgs(
+              params.jobId
+            )[0];
+          mutate(worksessionsByJobIdKey);
+        }
+
         if (params.handleSuccess) params.handleSuccess();
       },
       onError: () => {

--- a/hooks/api/user/jobChangeRequests/useAcceptJobChangeRequest.ts
+++ b/hooks/api/user/jobChangeRequests/useAcceptJobChangeRequest.ts
@@ -4,8 +4,10 @@ import { JobChangeRequests } from "@/api/__generated__/base/JobChangeRequests";
 import { useSWRConfig } from "swr";
 import { JobChangeRequestsListData, JobsDetailData } from "@/api/__generated__/base/data-contracts";
 import { Jobs } from "@/api/__generated__/base/Jobs";
+import { Users } from "@/api/__generated__/base/Users";
 export interface Params {
   jobChangeRequestId?: string;
+  userId?: string;
 }
 
 export const useAcceptJobChangeRequest = (params: Params) => {
@@ -53,6 +55,15 @@ export const useAcceptJobChangeRequest = (params: Params) => {
           };
         }
         , { revalidate: false });
+
+        if (params.userId) {
+          const users = getApi(Users);
+          const worksessionsByUserIdKey = users.worksessionsListQueryArgs(params.userId)[0];
+          mutate(worksessionsByUserIdKey);
+  
+          const worksessionsByUserIdTodoKey = users.worksessionsUserTodosListQueryArgs(params.userId)[0];
+          mutate(worksessionsByUserIdTodoKey);
+        }
       }
     }
   );

--- a/hooks/api/user/jobChangeRequests/useAcceptJobChangeRequest.ts
+++ b/hooks/api/user/jobChangeRequests/useAcceptJobChangeRequest.ts
@@ -46,7 +46,7 @@ export const useAcceptJobChangeRequest = (params: Params) => {
         mutate(jobKey, async (currentJob: JobsDetailData | undefined) => {
           if (!currentJob) return currentJob;
 
-          // レスポンスのidと一致するJobを見つけたら、更新されたデータで上書き
+          // 更新されたデータで上書き
           return {
             ...currentJob,
             job: data.job,

--- a/hooks/api/user/jobChangeRequests/useRejectJobChangeRequest.ts
+++ b/hooks/api/user/jobChangeRequests/useRejectJobChangeRequest.ts
@@ -2,6 +2,7 @@ import { getApi } from "@/api/api-factory";
 import useSWRMutation from "swr/mutation";
 import { JobChangeRequests } from "@/api/__generated__/base/JobChangeRequests";
 import { useSWRConfig } from "swr";
+import { JobChangeRequestsListData } from "@/api/__generated__/base/data-contracts";
 export interface Params {
   jobChangeRequestId?: string;
 }
@@ -25,7 +26,19 @@ export const useRejectJobChangeRequest = (params: Params) => {
         // Job変更リクエストのリストのキャッシュを更新
         const jobChangeRequestsKey =
           jobChangeRequests.jobChangeRequestsListQueryArgs()[0];
-        mutate(jobChangeRequestsKey);
+        mutate(jobChangeRequestsKey, async (currentItems: JobChangeRequestsListData | undefined) => {
+          if (!currentItems) return currentItems;
+
+          const updatedItems = currentItems.map((item) => {
+            if (item.id !== data.id) {
+              return item;
+            }
+            // レスポンスのidと一致するJob変更リクエストを見つけたら、更新されたデータで上書き
+            return data;
+          });
+
+          return updatedItems;
+        });
       }
     }
   );

--- a/hooks/api/user/messages/useSubscriptionMessageSummaryByUser.ts
+++ b/hooks/api/user/messages/useSubscriptionMessageSummaryByUser.ts
@@ -1,10 +1,11 @@
 import { getApi } from "@/api/api-factory";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import { Chat } from "@/api/__generated__/base/Chat";
 import useSWRSubscription from "swr/subscription";
 import realTimeClient from "@/api/xano";
 import { XanoRealtimeChannel } from "@xano/js-sdk/lib/models/realtime-channel";
 import { JobsDetailData, WorksessionsUserTodosListData } from "@/api/__generated__/base/data-contracts";
+import { JobChangeRequests } from "@/api/__generated__/base/JobChangeRequests";
 
 // XANOから生成されるSwaggerの定義が不完全なため、レスポンスの型を手動で定義する
 type FirstMessage = {
@@ -65,6 +66,8 @@ export interface Params {
 export const useSubscriptionMessageSummaryByUser = (
   params: Params,
 ) => {
+  const { mutate } = useSWRConfig();
+
   const chatApi = getApi(Chat);
   const channelKey = `user_chat/${params.userId}`;
 
@@ -105,6 +108,12 @@ export const useSubscriptionMessageSummaryByUser = (
                 }, 5000);
               } else {
                 getRequest.mutate();
+
+                // jobの変更リクエストの再取得
+                const jobChangeRequestsApi = getApi(JobChangeRequests);
+                const jobChangeRequestsKey = jobChangeRequestsApi.jobChangeRequestsListQueryArgs()[0];
+                mutate(jobChangeRequestsKey)
+
                 next();
               }
             });

--- a/hooks/api/user/messages/useUpdateReadMessageByUser.ts
+++ b/hooks/api/user/messages/useUpdateReadMessageByUser.ts
@@ -27,22 +27,19 @@ export const useUpdateReadMessageByUser = (params: Params) => {
         const messagesByUserIdKey = usersApi.worksessionsMessagesListQueryArgs(
           params.userId,
           params.workSessionId,
-          {
-            headers: {
-              "X-User-Type": "chef",
-            },
-          }
         )[0];
         mutate(messagesByUserIdKey);
       }
 
       // 未読のMessagesリストのキャッシュを更新
-      const unreadMessagesByUserIdKey = chat.unreadSummaryChefListQueryArgs({
-        headers: {
-          "X-User-Type": "chef",
-        },
-      })[0];
+      const unreadMessagesByUserIdKey = chat.unreadSummaryChefListQueryArgs()[0];
       mutate(unreadMessagesByUserIdKey);
+
+      // Messagesサマリーのキャッシュを更新
+      const messagesSummaryByUserIdKey = chat.summaryChefListQueryArgs({
+        user_id: params.userId ?? '',
+      })[0];
+      mutate(messagesSummaryByUserIdKey);
     },
   });
 };

--- a/hooks/api/user/reviews/useGetReviewsByUserId.ts
+++ b/hooks/api/user/reviews/useGetReviewsByUserId.ts
@@ -14,5 +14,8 @@ export const useGetReviewsByUserId = (
     headers: {
       "X-User-Type": "chef"
     }
-  }, params.userId != null));
+  }, params.userId != null), {
+    revalidateOnMount: true,
+    dedupingInterval: 0,
+  });
 };

--- a/hooks/api/user/worksessions/useCancelWorksessionByChef.ts
+++ b/hooks/api/user/worksessions/useCancelWorksessionByChef.ts
@@ -1,4 +1,5 @@
 import { Jobs } from "@/api/__generated__/base/Jobs";
+import { Users } from "@/api/__generated__/base/Users";
 import { Worksessions } from "@/api/__generated__/base/Worksessions";
 import { getApi } from "@/api/api-factory";
 import { useSWRConfig } from "swr";
@@ -6,7 +7,7 @@ import useSWRMutation from "swr/mutation";
 
 interface Params {
   worksessionId?: number;
-  jobId?: number;
+  userId?: string;
 }
 
 export const useCancelWorksessionByChef = (params: Params) => {
@@ -26,11 +27,15 @@ export const useCancelWorksessionByChef = (params: Params) => {
     {
       onSuccess: () => {
         // キャッシュを更新
-        if (params.jobId) {
-          const jobs = getApi(Jobs);
-          const worksessionsByJobIdKey =
-            jobs.worksessionsRestaurantTodosListQueryArgs(params.jobId)[0];
-          mutate(worksessionsByJobIdKey);
+        if (params.userId) {
+          const usersApi = getApi(Users);
+          const worksessionsByUserIdKey =
+            usersApi.worksessionsListQueryArgs(params.userId)[0];
+          mutate(worksessionsByUserIdKey);
+
+          const worksessionsByUserIdTodoKey =
+            usersApi.worksessionsUserTodosListQueryArgs(params.userId)[0];
+          mutate(worksessionsByUserIdTodoKey);
         }
       },
     }

--- a/hooks/api/user/worksessions/useFinishWorksession.ts
+++ b/hooks/api/user/worksessions/useFinishWorksession.ts
@@ -28,6 +28,9 @@ export const useFinishWorksession = (params: Params) => {
 
         const worksessionsByUserIdTodoKey = users.worksessionsUserTodosListQueryArgs(params.userId)[0];
         mutate(worksessionsByUserIdTodoKey);
+
+        const myReviews = users.chefReviewsListQueryArgs(params.userId)[0];
+        mutate(myReviews);
       }
 
       if (params.handleSuccess) {

--- a/hooks/api/user/worksessions/useGetWorksessionHistoryCurrentMonth.ts
+++ b/hooks/api/user/worksessions/useGetWorksessionHistoryCurrentMonth.ts
@@ -15,5 +15,8 @@ export const useGetWorksessionHistoryCurrentMonth = (
     headers: {
       "X-User-Type": "chef"
     }
-  }, params.userId != null));
+  }, params.userId != null), {
+    revalidateOnMount: true,
+    dedupingInterval: 0,
+  });
 };

--- a/hooks/api/user/worksessions/useGetWorksessionsByUserId.ts
+++ b/hooks/api/user/worksessions/useGetWorksessionsByUserId.ts
@@ -14,5 +14,8 @@ export const useGetWorksessionsByUserId = (
     headers: {
       "X-User-Type": "chef"
     }
-  }, params.userId != null));
+  }, params.userId != null), {
+    revalidateOnMount: true,
+    dedupingInterval: 0,
+  });
 };

--- a/hooks/api/user/worksessions/useGetWorksessionsByUserIdByTodo.ts
+++ b/hooks/api/user/worksessions/useGetWorksessionsByUserIdByTodo.ts
@@ -12,5 +12,8 @@ export const useGetWorksessionsByUserIdByTodo = (params: Params) => {
     headers: {
       "X-User-Type": "chef"
     }
-  }, params.userId != null));
+  }, params.userId != null), {
+    revalidateOnMount: true,
+    dedupingInterval: 0,
+  });
 }

--- a/lib/api/restaurant.ts
+++ b/lib/api/restaurant.ts
@@ -1,8 +1,8 @@
 import { apiRequest } from "./config";
 import { API_CONFIG } from "./config";
 import { getCompany } from "./company";
-import { Restaurant as RestaurantType } from "@/types/restaurant";
 import { CompanyUserNotification } from "./companyUserNotification";
+import { RESTAURANT_STATUS } from "../const/restaurant";
 
 const BASE_URL = API_CONFIG.baseURLs.restaurant;
 
@@ -37,6 +37,7 @@ export interface Restaurant {
   company?: Company;
   profile_image?: string;
   restaurant_cuisine_id?: number[] | number;
+  status: typeof RESTAURANT_STATUS[number]['value'];
 }
 
 export type CreateRestaurantData = {

--- a/lib/const/restaurant.ts
+++ b/lib/const/restaurant.ts
@@ -1,0 +1,7 @@
+export const RESTAURANT_STATUS = [
+  { id: "banned", label: "停止中", value: "BANNED" },
+  { id: "pending", label: "審査中", value: "PENDING" },
+  { id: "deleted", label: "削除済み", value: "DELETED" },
+  { id: "approved", label: "公開中", value: "APPROVED" },
+] as const;
+export type RestaurantStatus = typeof RESTAURANT_STATUS[number];

--- a/types/restaurant.ts
+++ b/types/restaurant.ts
@@ -1,3 +1,5 @@
+import { RESTAURANT_STATUS } from "@/lib/const/restaurant";
+
 export interface Restaurant {
   id: string;
   name: string;
@@ -6,4 +8,5 @@ export interface Restaurant {
   address?: string;
   companies_id: string;
   is_approved: boolean;
+  status: typeof RESTAURANT_STATUS[number]['value'];
 }


### PR DESCRIPTION
- 会社登録
    - 画像の登録を除外
    - 未使用の項目、フロントから渡す必要の無い項目を除外
- 会社編集
   - 請求先のメアドを編集可能にした
   - 未使用の項目、フロントから渡す必要の無い項目を除外
- Job変更リクエスト
   - フロントから渡す必要の無い項目を除外
   - admin/job/[id]のドロップダウンメニューのhoverの色がついていなかったので修正
- レストランの追加
   - 未使用の項目、フロントから渡す必要の無い項目を除外
- レストランの修正
    - 未使用の項目、フロントから渡す必要の無い項目を除外
- レストラン一覧、詳細
    - ジャンルが表示できていなかったので修正
    - is_approvedとis_active使ってるところをstatusを見るよう修正
    - 一覧にステータス表示
    - BANNEDのレストランの詳細を開いた時に薄いベールで覆って「停止中です」旨のポップアップ表示
    - APPROVED以外のレストランでは「求人を追加」が非活性になるようにした
- operator側のレストラン一覧（app/operator/restaurants/page.tsx）
    - is_approvedとis_active使ってるところをstatusを見るよう修正
- 関連データ更新時にデータ再取得する実装追加